### PR TITLE
Add batched inference support

### DIFF
--- a/ptts-wasm/src/lib.rs
+++ b/ptts-wasm/src/lib.rs
@@ -109,7 +109,7 @@ fn remap_key(name: &str) -> Option<String> {
 type RawState = StreamingTransformerState<f32, CpuDevice>;
 
 fn wrap_state<Q: BackendQ<T = f32, B = CpuDevice>>(raw: RawState) -> TTSState<Q> {
-    TTSState { flow_lm_state: FlowLMState { transformer_state: raw } }
+    TTSState { flow_lm_state: FlowLMState { transformer_state: raw, padding: None } }
 }
 
 /// Creates a new transformer state with a larger seq_budget, copying the used KV entries

--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -25,13 +25,16 @@ impl ptts::Tokenizer for SpTokenizer {
 #[command(name = "pocket-tts")]
 #[command(about = "Generate speech from text using Pocket TTS")]
 struct Args {
-    /// Text to synthesize
-    text: String,
+    #[command(subcommand)]
+    command: Option<Command>,
 
-    #[arg(long)]
+    /// Text to synthesize
+    text: Option<String>,
+
+    #[arg(long, global = true)]
     config: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     weights: Option<String>,
 
     #[arg(long)]
@@ -42,28 +45,28 @@ struct Args {
     output: std::path::PathBuf,
 
     /// Voice to use
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     voice: Option<String>,
 
     /// Sampling temperature
-    #[arg(short, long, default_value_t = 0.7)]
+    #[arg(short, long, default_value_t = 0.7, global = true)]
     temperature: f32,
 
     /// Sampling seed
-    #[arg(short, long, default_value_t = 4242424242424242)]
+    #[arg(short, long, default_value_t = 4242424242424242, global = true)]
     seed: u64,
 
     /// Use the cpu device even if a gpu backend is available
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = false, global = true)]
     cpu: bool,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     quant: Option<String>,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     chrome_tracing: bool,
 
-    #[arg(long)]
+    #[arg(long, global = true)]
     rng_values: Option<String>,
 
     #[arg(long)]
@@ -71,6 +74,38 @@ struct Args {
 
     #[arg(long)]
     pad_to: Option<usize>,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum Command {
+    /// Process a JSONL file of queries with batched inference.
+    Batch(BatchArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct BatchArgs {
+    /// JSONL file with one query per line: {"text": "...", "output": "optional/path.wav"}
+    input: std::path::PathBuf,
+
+    /// Number of queries processed simultaneously
+    #[arg(short, long, default_value_t = 8)]
+    batch_size: usize,
+
+    /// Directory used for output WAV files when a query has no explicit "output" field
+    #[arg(long, default_value = "batch-out")]
+    output_dir: std::path::PathBuf,
+
+    /// Number of threads used for the mimi audio decoding, the batch entries are split
+    /// evenly between the threads. Defaults to min(batch_size, 4).
+    #[arg(long)]
+    decode_threads: Option<usize>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct Query {
+    text: String,
+    #[serde(default)]
+    output: Option<String>,
 }
 
 const VOICES: &[&str] =
@@ -323,8 +358,101 @@ where
     })
 }
 
+/// Compute the voice conditioning embedding (and the null embedding used by cfg when
+/// applicable) from either a precomputed safetensors file or a raw audio prompt.
+#[allow(clippy::type_complexity)]
+fn load_voice_emb<Q: xn::BackendQ>(
+    voice: Voice,
+    vb: &xn::nn::var_builder::Path<Q::B>,
+    cfg: &TTSConfig,
+    dev: &Q::B,
+    with_cfg: bool,
+) -> Result<(Tensor<Q::T, Q::B>, Option<Tensor<Q::T, Q::B>>)> {
+    let (voice_emb, null_emb) = match voice {
+        Voice::Safetensors(voice_path) => {
+            let voice_vb = VB::load(&[&voice_path], dev.clone())?;
+            let voice_names = voice_vb.tensor_names();
+            let voice_key =
+                voice_names.first().context("no tensors found in voice embedding file")?;
+            let voice_shape = voice_vb.shape(voice_key).context("voice tensor not found")?;
+            let voice_dims = voice_shape.dims();
+
+            // Load as raw tensor and reshape to [1, T, dim]
+            let voice_emb: Tensor<f32, Q::B> = voice_vb.tensor(voice_key, voice_shape.clone())?;
+            let voice_emb = if voice_dims.len() == 2 {
+                voice_emb.reshape((1, voice_dims[0], voice_dims[1]))?
+            } else {
+                voice_emb
+            };
+            if with_cfg {
+                anyhow::bail!("cfg is not supported with pre-computed voice embeddings");
+            }
+            if let Some(model_ext) = cfg.model_ext() {
+                let file_content = std::fs::read(&voice_path)?;
+                let (_, metadata) = safetensors::SafeTensors::read_metadata(&file_content)?;
+                if let Some(metadata) = metadata.metadata()
+                    && let Some(voice_model_ext) = metadata.get("model_ext")
+                {
+                    tracing::info!(?voice_model_ext, "voice embedding model_ext from metadata");
+                    if voice_model_ext.as_str() != model_ext {
+                        anyhow::bail!(
+                            "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
+                        );
+                    }
+                }
+            }
+            (voice_emb.to::<Q::T>()?, None)
+        }
+        Voice::Audio(path) => {
+            tracing::info!("loading voice from audio file {}", path);
+            let (mut pcm, sample_rate) = audio_helpers::pcm_decode(&path)?;
+            ptts::utils::normalize_loudness(&mut pcm, sample_rate)?;
+            let sample_rate = sample_rate as usize;
+            let pcm = if sample_rate != cfg.mimi.sample_rate {
+                audio_helpers::resample(&pcm, sample_rate, cfg.mimi.sample_rate)?
+            } else {
+                pcm
+            };
+            tracing::info!("loaded audio with {} samples", pcm.len());
+            let sr = cfg.mimi.sample_rate as f32;
+            let min_len = (sr * cfg.audio_prompt_min_duration).round() as usize;
+            let max_len = (sr * cfg.audio_prompt_max_duration).round() as usize;
+            let pcm = if pcm.len() > max_len {
+                tracing::info!(
+                    max_duration = cfg.audio_prompt_max_duration,
+                    "trimming audio to max duration"
+                );
+                pcm[..max_len].to_vec()
+            } else {
+                pcm
+            };
+            if pcm.len() < min_len {
+                anyhow::bail!(
+                    "audio prompt is shorter than min duration ({}s, {} samples; got {})",
+                    cfg.audio_prompt_min_duration,
+                    min_len,
+                    pcm.len()
+                );
+            }
+            let pcm_tensor = Tensor::from_vec(pcm, (1, 1, ()), dev)?.to::<Q::T>()?;
+            let mimi_enc: MimiEnc<Q> = MimiEnc::load(vb, cfg)?;
+            let emb = mimi_enc.encode_audio(&pcm_tensor)?;
+            tracing::info!(?emb, "encoded audio to latent");
+            let null_emb = if with_cfg && !cfg.cfg_null_audio_empty {
+                let null_pcm_tensor = pcm_tensor.zeros_like()?;
+                Some(mimi_enc.encode_audio(&null_pcm_tensor)?)
+            } else {
+                None
+            };
+            (emb, null_emb)
+        }
+    };
+    Ok((voice_emb, null_emb))
+}
+
 fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()> {
     use std::str::FromStr;
+    let with_cfg = !matches!(args.cfg_coef, Some(1.0) | None);
     let (model_path, tokenizer_path, voice, cfg) = match args.config.as_ref() {
         Some(config) => {
             let config = std::fs::canonicalize(config)?;
@@ -337,7 +465,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
             tracing::info!(?config, "using local config");
             let config: ptts::tts_model::TTSConfig =
                 serde_json::from_str(&std::fs::read_to_string(config)?)?;
-            let voice = match args.voice {
+            let voice = match args.voice.as_ref() {
                 None => None,
                 Some(voice) if voice.ends_with(".safetensors") => {
                     let voice_path = std::path::PathBuf::from(voice);
@@ -346,7 +474,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
                     }
                     Some(Voice::Safetensors(voice_path))
                 }
-                Some(voice) => Some(Voice::Audio(voice)),
+                Some(voice) => Some(Voice::Audio(voice.clone())),
             };
             (model_path, tokenizer_path, voice, config)
         }
@@ -354,7 +482,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
             if args.weights.is_some() {
                 anyhow::bail!("--weights option is not supported without --config");
             }
-            let voice = args.voice.unwrap_or("alba".to_string());
+            let voice = args.voice.clone().unwrap_or("alba".to_string());
             if !VOICES.contains(&voice.as_str()) && !std::path::PathBuf::from(&voice).exists() {
                 anyhow::bail!("unknown voice '{voice}'. Available voices: {}", VOICES.join(", "));
             }
@@ -367,10 +495,9 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
     let tokenizer_path = tokenizer_path.to_str().context("invalid tokenizer path")?;
     let sp = sentencepiece::SentencePieceProcessor::open(tokenizer_path)?;
     let tokenizer = SpTokenizer(sp);
-    let chunks = split_into_best_sentences(&tokenizer, &args.text, None)?;
 
-    let mut rng = match args.rng_values {
-        Some(path) => Rng::from_file(&path)?,
+    let rng = match args.rng_values.as_ref() {
+        Some(path) => Rng::from_file(path)?,
         None => Rng::std_rng(args.temperature, args.seed)?,
     };
 
@@ -402,6 +529,37 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
     })?;
     tracing::info!("model loaded successfully!");
 
+    let voice_embs = match voice {
+        Some(voice) => Some(load_voice_emb::<Q>(voice, &vb, &cfg, &dev, with_cfg)?),
+        None => None,
+    };
+    let model = std::sync::Arc::new(model);
+
+    match args.command {
+        Some(Command::Batch(ref batch_args)) => {
+            if with_cfg {
+                anyhow::bail!("--cfg_coef is not supported in batch mode");
+            }
+            run_batch::<Q>(batch_args, model, &cfg, voice_embs.map(|v| v.0), rng, &dev)
+        }
+        None => run_single::<Q>(&args, model, &cfg, voice_embs, rng, &dev),
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn run_single<Q: xn::BackendQ + 'static>(
+    args: &Args,
+    model: std::sync::Arc<TTSModel<Q>>,
+    cfg: &TTSConfig,
+    voice_embs: Option<(Tensor<Q::T, Q::B>, Option<Tensor<Q::T, Q::B>>)>,
+    mut rng: Rng,
+    dev: &Q::B,
+) -> Result<()> {
+    let text = args.text.as_ref().context("no text to synthesize provided")?;
+    let tokenizer: &dyn ptts::Tokenizer =
+        model.flow_lm.conditioner.tokenizer.as_deref().context("model has no tokenizer")?;
+    let chunks = split_into_best_sentences(tokenizer, text, None)?;
+
     let mut max_seq_budget = 0;
     let mut all_tokens = vec![];
     for chunk in chunks.iter() {
@@ -427,87 +585,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
     let mimi_state = model.init_mimi_state(1, 250)?;
 
     // Load voice embedding
-    if let Some(voice) = voice {
-        let (voice_emb, null_emb) = match voice {
-            Voice::Safetensors(voice_path) => {
-                let voice_vb = VB::load(&[&voice_path], dev.clone())?;
-                let voice_names = voice_vb.tensor_names();
-                let voice_key =
-                    voice_names.first().context("no tensors found in voice embedding file")?;
-                let voice_shape = voice_vb.shape(voice_key).context("voice tensor not found")?;
-                let voice_dims = voice_shape.dims();
-
-                // Load as raw tensor and reshape to [1, T, dim]
-                let voice_emb: Tensor<f32, Q::B> =
-                    voice_vb.tensor(voice_key, voice_shape.clone())?;
-                let voice_emb = if voice_dims.len() == 2 {
-                    voice_emb.reshape((1, voice_dims[0], voice_dims[1]))?
-                } else {
-                    voice_emb
-                };
-                if cfg_state.is_some() {
-                    anyhow::bail!("cfg is not supported with pre-computed voice embeddings");
-                }
-                if let Some(model_ext) = cfg.model_ext() {
-                    let file_content = std::fs::read(&voice_path)?;
-                    let (_, metadata) = safetensors::SafeTensors::read_metadata(&file_content)?;
-                    if let Some(metadata) = metadata.metadata()
-                        && let Some(voice_model_ext) = metadata.get("model_ext")
-                    {
-                        tracing::info!(?voice_model_ext, "voice embedding model_ext from metadata");
-                        if voice_model_ext.as_str() != model_ext {
-                            anyhow::bail!(
-                                "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
-                            );
-                        }
-                    }
-                }
-                (voice_emb.to::<Q::T>()?, None)
-            }
-            Voice::Audio(path) => {
-                tracing::info!("loading voice from audio file {}", path);
-                let (mut pcm, sample_rate) = audio_helpers::pcm_decode(&path)?;
-                ptts::utils::normalize_loudness(&mut pcm, sample_rate)?;
-                let sample_rate = sample_rate as usize;
-                let pcm = if sample_rate != cfg.mimi.sample_rate {
-                    audio_helpers::resample(&pcm, sample_rate, cfg.mimi.sample_rate)?
-                } else {
-                    pcm
-                };
-                tracing::info!("loaded audio with {} samples", pcm.len());
-                let sr = cfg.mimi.sample_rate as f32;
-                let min_len = (sr * cfg.audio_prompt_min_duration).round() as usize;
-                let max_len = (sr * cfg.audio_prompt_max_duration).round() as usize;
-                let pcm = if pcm.len() > max_len {
-                    tracing::info!(
-                        max_duration = cfg.audio_prompt_max_duration,
-                        "trimming audio to max duration"
-                    );
-                    pcm[..max_len].to_vec()
-                } else {
-                    pcm
-                };
-                if pcm.len() < min_len {
-                    anyhow::bail!(
-                        "audio prompt is shorter than min duration ({}s, {} samples; got {})",
-                        cfg.audio_prompt_min_duration,
-                        min_len,
-                        pcm.len()
-                    );
-                }
-                let pcm_tensor = Tensor::from_vec(pcm, (1, 1, ()), &dev)?.to::<Q::T>()?;
-                let mimi_enc: MimiEnc<Q> = MimiEnc::load(&vb, &cfg)?;
-                let emb = mimi_enc.encode_audio(&pcm_tensor)?;
-                tracing::info!(?emb, "encoded audio to latent");
-                let null_emb = if cfg_state.is_some() && !cfg.cfg_null_audio_empty {
-                    let null_pcm_tensor = pcm_tensor.zeros_like()?;
-                    Some(mimi_enc.encode_audio(&null_pcm_tensor)?)
-                } else {
-                    None
-                };
-                (emb, null_emb)
-            }
-        };
+    if let Some((voice_emb, null_emb)) = voice_embs {
         // Prompt with audio conditioning
         tracing::info!("prompting with voice conditioning ({} frames)...", voice_emb.dim(1usize)?);
         let start = std::time::Instant::now();
@@ -525,7 +603,6 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
     tracing::info!("starting generation...");
     let mut all_audios = vec![];
     let mut backbone_step_timings_ms = vec![];
-    let model = std::sync::Arc::new(model);
     for (tokens, max_frames, frames_after_eos) in all_tokens.into_iter() {
         tracing::info!("prompting with text conditioning ({} tokens)...", tokens.len());
         let start = std::time::Instant::now();
@@ -546,7 +623,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
         let ldim = cfg.flow_lm.ldim;
         let nan_data: Vec<f32> = vec![f32::NAN; ldim];
         let mut prev_latent: Tensor<Q::T, Q::B> =
-            Tensor::from_vec(nan_data, (1, 1, ldim), &dev)?.to::<Q::T>()?;
+            Tensor::from_vec(nan_data, (1, 1, ldim), dev)?.to::<Q::T>()?;
 
         let mut eos_countdown: Option<usize> = None;
 
@@ -636,5 +713,243 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
     let mut writer = std::io::BufWriter::new(output_file);
     ptts::wav::write_pcm_as_wav(&mut writer, &pcm, cfg.mimi.sample_rate as u32, 1)?;
     tracing::info!("saving output to {}", args.output.display());
+    Ok(())
+}
+
+struct WorkItem {
+    query_idx: usize,
+    tokens: Vec<u32>,
+    max_frames: usize,
+    frames_after_eos: usize,
+}
+
+fn run_batch<Q: xn::BackendQ + 'static>(
+    batch_args: &BatchArgs,
+    model: std::sync::Arc<TTSModel<Q>>,
+    cfg: &TTSConfig,
+    voice_emb: Option<Tensor<Q::T, Q::B>>,
+    mut rng: Rng,
+    dev: &Q::B,
+) -> Result<()> {
+    let tokenizer: &dyn ptts::Tokenizer =
+        model.flow_lm.conditioner.tokenizer.as_deref().context("model has no tokenizer")?;
+
+    let input = std::fs::read_to_string(&batch_args.input)
+        .with_context(|| format!("cannot read '{}'", batch_args.input.display()))?;
+    let queries = input
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(serde_json::from_str)
+        .collect::<std::result::Result<Vec<Query>, _>>()
+        .context("invalid jsonl input")?;
+    if queries.is_empty() {
+        anyhow::bail!("no queries found in '{}'", batch_args.input.display());
+    }
+
+    // Split each query into sentence chunks; each chunk is an independent work item.
+    let mut items = vec![];
+    let mut max_seq_budget = 0;
+    for (query_idx, query) in queries.iter().enumerate() {
+        for chunk in split_into_best_sentences(tokenizer, &query.text, None)?.iter() {
+            let (text, frames_after_eos) = prepare_text_prompt(chunk);
+            let tokens = model.flow_lm.conditioner.tokenize(&text)?;
+            let max_frames = ((tokens.len() as f64 / 3.0 + 2.0) * 12.5).ceil() as usize;
+            max_seq_budget = max_seq_budget.max(tokens.len() + 512 + max_frames);
+            items.push(WorkItem { query_idx, tokens, max_frames, frames_after_eos });
+        }
+    }
+    let batch_size = batch_args.batch_size.min(items.len()).max(1);
+    // The mimi decoding of the batch entries is split over several threads, each thread
+    // owning the mimi streaming state of a contiguous slice of the batch.
+    let decode_threads =
+        batch_args.decode_threads.unwrap_or(batch_size.min(4)).clamp(1, batch_size);
+    let mut slice_bounds = Vec::with_capacity(decode_threads);
+    let mut slice_start = 0;
+    for t in 0..decode_threads {
+        let slice_len = batch_size / decode_threads + usize::from(t < batch_size % decode_threads);
+        slice_bounds.push((slice_start, slice_len));
+        slice_start += slice_len;
+    }
+    tracing::info!(
+        num_queries = queries.len(),
+        num_chunks = items.len(),
+        batch_size,
+        decode_threads,
+        "batch mode"
+    );
+
+    // Group chunks of similar expected lengths together to limit the number of wasted
+    // generation steps within a batch.
+    let mut order: Vec<usize> = (0..items.len()).collect();
+    order.sort_by_key(|&i| items[i].max_frames);
+
+    // Prime a state with the voice conditioning once, then clone it for every batch.
+    let mut base_state = model.init_flow_lm_state(batch_size, max_seq_budget)?;
+    if let Some(voice_emb) = voice_emb {
+        let (_, t, d) = voice_emb.dims3()?;
+        let voice_emb = voice_emb.expand((batch_size, t, d))?.contiguous()?;
+        tracing::info!("prompting with voice conditioning ({t} frames)...");
+        let start = std::time::Instant::now();
+        model.prompt_audio(&mut base_state, &voice_emb)?;
+        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+        tracing::info!("done prompting with voice conditioning in {elapsed_ms:.2}ms");
+    }
+
+    let start = std::time::Instant::now();
+    tracing::info!("starting generation...");
+    let ldim = cfg.flow_lm.ldim;
+    let mut results: Vec<Option<Vec<f32>>> = (0..items.len()).map(|_| None).collect();
+    let mut backbone_step_timings_ms = vec![];
+    let mut generated_frames = 0usize;
+    let mut used_frames = 0usize;
+    for batch in order.chunks(batch_size) {
+        // Pad incomplete batches by repeating the last item; the extra outputs are discarded.
+        let mut batch_items = batch.to_vec();
+        while batch_items.len() < batch_size {
+            batch_items.push(*batch.last().context("empty batch")?);
+        }
+
+        let mut tts_state = base_state.clone();
+        let token_batch = batch_items.iter().map(|&i| items[i].tokens.clone()).collect::<Vec<_>>();
+        let prompt_start = std::time::Instant::now();
+        model.prompt_text_batch(&mut tts_state, &token_batch)?;
+        let elapsed_ms = prompt_start.elapsed().as_secs_f64() * 1000.0;
+        tracing::info!("prompted batch of {} texts in {elapsed_ms:.2}ms", batch_items.len());
+
+        // BOS marker: NaN tensor [B, 1, ldim]
+        let nan_data: Vec<f32> = vec![f32::NAN; batch_size * ldim];
+        let mut prev_latent: Tensor<Q::T, Q::B> =
+            Tensor::from_vec(nan_data, (batch_size, 1, ldim), dev)?.to::<Q::T>()?;
+
+        let mut eos_countdowns: Vec<Option<usize>> = vec![None; batch_size];
+        // Number of latent frames to keep for each batch entry once it is done.
+        let mut done_frames: Vec<Option<usize>> = vec![None; batch_size];
+        let max_steps =
+            batch_items.iter().map(|&i| items[i].max_frames).max().context("empty batch")?;
+
+        let mut latent_txs = Vec::with_capacity(decode_threads);
+        let mut decode_jhs = Vec::with_capacity(decode_threads);
+        for &(slice_start, slice_len) in slice_bounds.iter() {
+            let (latent_tx, latent_rx) = std::sync::mpsc::channel::<Tensor<Q::T, Q::B>>();
+            let mut mimi_state = model.init_mimi_state(slice_len, 250)?;
+            let jh = spawn({
+                let model = model.clone();
+                move || {
+                    let mut audio_chunks: Vec<Tensor<f32, Q::B>> = Vec::new();
+                    let mut chunk_samples: Vec<usize> = Vec::new();
+                    while let Ok(next_latent) = latent_rx.recv() {
+                        let latent = next_latent
+                            .narrow(0, slice_start..slice_start + slice_len)?
+                            .contiguous()?;
+                        let audio_chunk = model.decode_latent(&latent, &mut mimi_state)?;
+                        chunk_samples.push(audio_chunk.dim(2)?);
+                        audio_chunks.push(audio_chunk);
+                    }
+                    let audio_refs: Vec<&Tensor<f32, Q::B>> = audio_chunks.iter().collect();
+                    let audio = Tensor::cat(&audio_refs, 2)?;
+                    Ok::<_, anyhow::Error>((audio, chunk_samples))
+                }
+            });
+            latent_txs.push(latent_tx);
+            decode_jhs.push(jh);
+        }
+
+        for step in 0..max_steps {
+            let step_start = std::time::Instant::now();
+            let (next_latent, is_eos) =
+                model.generate_step_batch(&mut tts_state, &prev_latent, &mut rng)?;
+            backbone_step_timings_ms.push(step_start.elapsed().as_secs_f64() * 1000.0);
+            for latent_tx in latent_txs.iter() {
+                latent_tx.send(next_latent.clone())?;
+            }
+            generated_frames += batch_size;
+
+            let frames = step + 1;
+            for (b, &item_idx) in batch_items.iter().enumerate() {
+                if done_frames[b].is_some() {
+                    continue;
+                }
+                let item = &items[item_idx];
+                if is_eos[b] && eos_countdowns[b].is_none() {
+                    eos_countdowns[b] = Some(item.frames_after_eos);
+                }
+                if let Some(ref mut countdown) = eos_countdowns[b] {
+                    if *countdown == 0 {
+                        done_frames[b] = Some(frames);
+                        continue;
+                    }
+                    *countdown -= 1;
+                }
+                if frames >= item.max_frames {
+                    done_frames[b] = Some(frames);
+                }
+            }
+            if done_frames.iter().all(|d| d.is_some()) {
+                break;
+            }
+            prev_latent = next_latent;
+
+            if (step + 1) % 25 == 0 {
+                tracing::info!(?step, ?max_steps, "generation progress");
+            }
+        }
+        std::mem::drop(latent_txs); // Close channels to signal the decode threads to finish
+        for (&(slice_start, slice_len), jh) in slice_bounds.iter().zip(decode_jhs) {
+            let (audio, chunk_samples) =
+                jh.join().map_err(|_| anyhow::anyhow!("cannot join thread"))?;
+            for row in 0..slice_len {
+                let b = slice_start + row;
+                if b >= batch.len() {
+                    // Padding entry duplicated from the last item, discard it.
+                    continue;
+                }
+                let item_idx = batch_items[b];
+                let n_frames = done_frames[b].unwrap_or(chunk_samples.len());
+                used_frames += n_frames;
+                let n_samples: usize = chunk_samples[..n_frames].iter().sum();
+                let pcm = audio.narrow(0, row..row + 1)?.contiguous()?.to_vec()?;
+                results[item_idx] = Some(pcm[..n_samples].to_vec());
+            }
+        }
+    }
+
+    // Group the chunk audios back per query (items are created in query order, so the
+    // chunks of a query appear in the right order when scanning `results` sequentially).
+    let mut per_query_pcm: Vec<Vec<f32>> = (0..queries.len()).map(|_| vec![]).collect();
+    for (item, result) in items.iter().zip(results) {
+        let pcm = result.context("missing result for a chunk")?;
+        per_query_pcm[item.query_idx].extend_from_slice(&pcm);
+    }
+
+    let total_samples: usize = per_query_pcm.iter().map(|p| p.len()).sum();
+    let duration = total_samples as f64 / cfg.mimi.sample_rate as f64;
+    let elapsed = start.elapsed().as_secs_f64();
+    let rtf = duration / elapsed;
+    tracing::info!("generated {duration:.2}s in {elapsed:.2}s (RTF={rtf:.3})");
+    let nsteps = backbone_step_timings_ms.len();
+    tracing::info!(
+        ?nsteps,
+        batch_size,
+        "average backbone step time: {:.2}ms",
+        backbone_step_timings_ms.iter().sum::<f64>() / nsteps as f64
+    );
+    tracing::info!(
+        generated_frames,
+        used_frames,
+        "batch efficiency: {:.1}%",
+        100.0 * used_frames as f64 / generated_frames.max(1) as f64
+    );
+
+    std::fs::create_dir_all(&batch_args.output_dir)?;
+    for (query_idx, (query, pcm)) in queries.iter().zip(per_query_pcm.iter()).enumerate() {
+        let output_path = match query.output.as_ref() {
+            Some(p) => std::path::PathBuf::from(p),
+            None => batch_args.output_dir.join(format!("query-{query_idx:04}.wav")),
+        };
+        let output_file = std::fs::File::create(&output_path)?;
+        let mut writer = std::io::BufWriter::new(output_file);
+        ptts::wav::write_pcm_as_wav(&mut writer, pcm, cfg.mimi.sample_rate as u32, 1)?;
+        tracing::info!("saved output to {}", output_path.display());
+    }
     Ok(())
 }

--- a/ptts/src/conditioners.rs
+++ b/ptts/src/conditioners.rs
@@ -7,6 +7,7 @@ pub struct LUTConditioner<T: WithDTypeF, B: Backend> {
     embed: Tensor<T, B>,
     learnt_padding: Option<Tensor<T, B>>,
     learnt_padding_id: Option<u32>,
+    n_bins: usize,
     pub dim: usize,
     pub output_dim: usize,
 }
@@ -39,11 +40,19 @@ impl<T: WithDTypeF, B: Backend> LUTConditioner<T, B> {
             }
             None => (embed, None),
         };
-        Ok(Self { tokenizer, embed, dim, output_dim, learnt_padding, learnt_padding_id })
+        Ok(Self { tokenizer, embed, n_bins, dim, output_dim, learnt_padding, learnt_padding_id })
     }
 
     pub fn learnt_padding_id(&self) -> Option<u32> {
         self.learnt_padding_id
+    }
+
+    /// Token id used to pad batches of text prompts to a common length. This is the
+    /// learnt padding embedding when the model has one, and the `n_bins` padding entry
+    /// of the embedding table otherwise (the table has `n_bins + 1` rows, the extra one
+    /// being reserved for padding).
+    pub fn pad_token_id(&self) -> u32 {
+        self.learnt_padding_id.unwrap_or(self.n_bins as u32)
     }
 
     /// Tokenize text and return token ids.

--- a/ptts/src/flow_lm.rs
+++ b/ptts/src/flow_lm.rs
@@ -70,6 +70,55 @@ pub struct FlowLM<Q: BackendQ> {
 #[derive(Clone, Debug)]
 pub struct FlowLMState<Q: BackendQ> {
     pub transformer_state: StreamingTransformerState<Q::T, Q::B>,
+    /// Per-item key-padding flags covering every position processed so far,
+    /// `padding[b][p]` being true when position `p` of batch item `b` is a padding
+    /// position that must not be attended to. `None` when the stream contains no
+    /// padding at all (the common case), which skips the mask computation entirely.
+    pub padding: Option<Vec<Vec<bool>>>,
+}
+
+impl<Q: BackendQ> FlowLMState<Q> {
+    /// Number of positions processed so far.
+    pub fn current_end(&self) -> usize {
+        match self.transformer_state.layer_states.first() {
+            Some(crate::transformer::LayerAttentionState::FlowLm(s)) => s.current_end,
+            Some(crate::transformer::LayerAttentionState::Mimi(s)) => s.absolute_offset(),
+            None => 0,
+        }
+    }
+
+    /// Record the padding flags for `new_padding.len()` new positions of each batch
+    /// item before they get processed. Once padding tracking is enabled (some
+    /// position of some item was padded), it stays on for the whole stream.
+    pub fn extend_padding(&mut self, new_padding: &[Vec<bool>]) -> xn::Result<()> {
+        let any_padding = new_padding.iter().any(|row| row.iter().any(|&p| p));
+        if self.padding.is_none() && !any_padding {
+            return Ok(());
+        }
+        let current_end = self.current_end();
+        let padding =
+            self.padding.get_or_insert_with(|| vec![vec![false; current_end]; new_padding.len()]);
+        if padding.len() != new_padding.len() {
+            xn::bail!(
+                "batch size mismatch in padding tracking: {} vs {}",
+                padding.len(),
+                new_padding.len()
+            )
+        }
+        for (row, new_row) in padding.iter_mut().zip(new_padding.iter()) {
+            row.extend_from_slice(new_row);
+        }
+        Ok(())
+    }
+
+    /// Record `len` new non-padding positions for each batch item.
+    pub fn extend_valid(&mut self, len: usize) {
+        if let Some(padding) = self.padding.as_mut() {
+            for row in padding.iter_mut() {
+                row.extend(std::iter::repeat_n(false, len));
+            }
+        }
+    }
 }
 
 impl<Q: BackendQ> FlowLM<Q> {
@@ -145,7 +194,7 @@ impl<Q: BackendQ> FlowLM<Q> {
 
     pub fn init_state(&self, batch_size: usize, sequence_length: usize) -> Result<FlowLMState<Q>> {
         let transformer_state = self.transformer.init_state(batch_size, sequence_length)?;
-        Ok(FlowLMState { transformer_state })
+        Ok(FlowLMState { transformer_state, padding: None })
     }
 
     /// Run the backbone: concat text_embeddings + input, run transformer, strip prefix.
@@ -161,7 +210,12 @@ impl<Q: BackendQ> FlowLM<Q> {
             None => input.clone(),
         };
         let input = Tensor::cat(&[text_embeddings, &input], 1)?;
-        let out = self.transformer.forward(&input, &mut state.transformer_state)?;
+        state.extend_valid(input.dim(1usize)?);
+        let out = self.transformer.forward_masked(
+            &input,
+            &mut state.transformer_state,
+            state.padding.as_deref(),
+        )?;
         let out = out.layer_norm(&self.out_norm_weight, &self.out_norm_bias, 1e-5)?;
         // Remove prefix, keep only last seq_len positions
         let total = out.dim(1usize)?;
@@ -170,7 +224,7 @@ impl<Q: BackendQ> FlowLM<Q> {
     }
 
     /// Sample next latent using flow matching.
-    /// Returns (next_latent [B, 1, ldim], is_eos [B, 1]).
+    /// Returns (next_latent [B, 1, ldim], is_eos).
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub fn sample_next_latent(
         &self,
@@ -181,6 +235,29 @@ impl<Q: BackendQ> FlowLM<Q> {
         rng: &mut impl Rng,
         eos_threshold: f32,
     ) -> Result<(Tensor<Q::T, Q::B>, bool)> {
+        let (latent, is_eos) = self.sample_next_latents(
+            sequence,
+            text_embeddings,
+            state,
+            lsd_decode_steps,
+            rng,
+            eos_threshold,
+        )?;
+        Ok((latent, is_eos[0]))
+    }
+
+    /// Batched variant of `sample_next_latent`.
+    /// Returns (next_latent [B, 1, ldim], per-item is_eos flags of length B).
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    pub fn sample_next_latents(
+        &self,
+        sequence: &Tensor<Q::T, Q::B>,
+        text_embeddings: &Tensor<Q::T, Q::B>,
+        state: &mut FlowLMState<Q>,
+        lsd_decode_steps: usize,
+        rng: &mut impl Rng,
+        eos_threshold: f32,
+    ) -> Result<(Tensor<Q::T, Q::B>, Vec<bool>)> {
         let (b, s, _) = sequence.dims3()?;
         let dev = sequence.device();
 
@@ -193,7 +270,7 @@ impl<Q: BackendQ> FlowLM<Q> {
 
         let eos_logit = self.out_eos.forward(&transformer_out)?;
         let eos_val = eos_logit.to_vec()?;
-        let is_eos = eos_val[0].to_f32() > eos_threshold;
+        let is_eos = eos_val.iter().map(|v| v.to_f32() > eos_threshold).collect::<Vec<_>>();
         let noise_data: Vec<Q::T> =
             (0..b * self.ldim).map(|_| Q::T::from_f32(rng.sample())).collect();
         let noise = Tensor::from_vec(noise_data, (b, self.ldim), dev)?;

--- a/ptts/src/rope.rs
+++ b/ptts/src/rope.rs
@@ -37,6 +37,44 @@ impl<T: WithDTypeF, B: Backend> RotaryEmbedding<T, B> {
         Ok(Self { cos, sin })
     }
 
+    /// Build per-batch-item cos/sin tables: `positions[b][i]` is the rope position of
+    /// the i-th new step for batch item `b`. This lets items of a batch advance their
+    /// positions independently, e.g. when some of them carry padding that should not
+    /// consume a position.
+    pub fn new_per_item(
+        head_dim: usize,
+        positions: &[Vec<usize>],
+        max_period: f32,
+        device: &B,
+    ) -> Result<Self> {
+        let half_dim = head_dim / 2;
+        let mut inv_freq = Vec::with_capacity(half_dim);
+        for i in 0..half_dim {
+            inv_freq.push(1.0f32 / max_period.powf(i as f32 / half_dim as f32));
+        }
+
+        let batch_size = positions.len();
+        let seq_len = positions.first().map_or(0, |p| p.len());
+        let mut cos_data = Vec::with_capacity(batch_size * seq_len * half_dim);
+        let mut sin_data = Vec::with_capacity(batch_size * seq_len * half_dim);
+        for row in positions.iter() {
+            if row.len() != seq_len {
+                xn::bail!("inconsistent per-item position lengths: {} vs {seq_len}", row.len())
+            }
+            for &pos in row.iter() {
+                for &freq in &inv_freq {
+                    let angle = pos as f32 * freq;
+                    cos_data.push(T::from_f32(angle.cos()));
+                    sin_data.push(T::from_f32(angle.sin()));
+                }
+            }
+        }
+
+        let cos = Tensor::from_vec(cos_data, (batch_size, seq_len, half_dim), device)?;
+        let sin = Tensor::from_vec(sin_data, (batch_size, seq_len, half_dim), device)?;
+        Ok(Self { cos, sin })
+    }
+
     /// Apply RoPE to q and k tensors in [B, T, H, D] layout.
     /// Internally transposes to [B, H, T, D] for the `rope_i` primitive.
     pub fn forward(

--- a/ptts/src/transformer.rs
+++ b/ptts/src/transformer.rs
@@ -119,10 +119,11 @@ impl<Q: BackendQ> StreamingMultiheadAttention<Q> {
         let (q, k) = rope.forward(&q, &k)?;
         let (k, v) = state.complete_kv(&k, &v)?;
 
-        // Transpose to [b, h, t, d] for attention
-        let q = q.transpose(1, 2)?;
-        let k = k.transpose(1, 2)?;
-        let v = v.transpose(1, 2)?;
+        // Transpose to [b, h, t, d] for attention. The `contiguous` calls matter: the
+        // batched matmuls mis-handle transposed (strided) inputs for batch sizes > 1.
+        let q = q.transpose(1, 2)?.contiguous()?;
+        let k = k.transpose(1, 2)?.contiguous()?;
+        let v = v.transpose(1, 2)?.contiguous()?;
 
         // Scaled dot-product attention
         let scale = Q::T::from_f32(1.0 / (d as f32).sqrt());
@@ -135,10 +136,43 @@ impl<Q: BackendQ> StreamingMultiheadAttention<Q> {
         let x = attn.matmul(&v)?;
 
         // Back to [b, t, h*d]
-        let x = x.transpose(1, 2)?.reshape((b, t, self.embed_dim))?.contiguous()?;
+        let x = x.transpose(1, 2)?.contiguous()?.reshape((b, t, self.embed_dim))?;
         self.out_proj.forward(&x)
     }
 }
+/// Build a per-batch additive attention mask of shape [B, 1, num_queries, num_keys]
+/// combining the causal structure with per-item key-padding: padded positions are
+/// never attended to by other positions. A padded position may still attend to
+/// itself so that its (discarded) output stays finite even when every other key is
+/// masked out.
+fn materialize_padded_causal_mask<T: WithDTypeF, B: Backend>(
+    state: &StreamingMHAState<T, B>,
+    num_queries: usize,
+    key_padding: &[Vec<bool>],
+    dev: &B,
+) -> Result<Tensor<T, B>> {
+    let offset = state.current_end;
+    let num_keys = offset + num_queries;
+    let batch_size = key_padding.len();
+    let mut data = Vec::with_capacity(batch_size * num_queries * num_keys);
+    for padding in key_padding.iter() {
+        if padding.len() != num_keys {
+            xn::bail!(
+                "unexpected key-padding length {} for {num_keys} attended positions",
+                padding.len()
+            )
+        }
+        for q in 0..num_queries {
+            let q_abs = q + offset;
+            for (k, &is_padding) in padding.iter().enumerate() {
+                let visible = k <= q_abs && (!is_padding || k == q_abs);
+                data.push(T::from_f32(if visible { 0.0 } else { f32::NEG_INFINITY }));
+            }
+        }
+    }
+    Tensor::from_vec(data, (batch_size, 1, num_queries, num_keys), dev)
+}
+
 // ---- KV Cache ----
 
 /// Simple append-based KV cache with optional context window trimming.
@@ -153,6 +187,10 @@ pub struct KvCache<T: WithDTypeF, B: Backend> {
 impl<T: WithDTypeF, B: Backend> KvCache<T, B> {
     pub fn new(context: usize) -> Self {
         Self { k: None, v: None, context, absolute_offset: 0 }
+    }
+
+    pub fn absolute_offset(&self) -> usize {
+        self.absolute_offset
     }
 
     pub fn current_seq_len(&self) -> Result<usize> {
@@ -457,10 +495,26 @@ impl<Q: BackendQ> StreamingTransformer<Q> {
         x: &Tensor<Q::T, Q::B>,
         state: &mut StreamingTransformerState<Q::T, Q::B>,
     ) -> Result<Tensor<Q::T, Q::B>> {
+        self.forward_masked(x, state, None)
+    }
+
+    /// Forward pass with an optional per-item key-padding mask. `key_padding[b][p]` is
+    /// true when the absolute position `p` of batch item `b` holds padding and must not
+    /// be attended to; each row must cover all positions processed so far plus the new
+    /// ones (`current_end + seq_len`). Only supported by flow-lm style attention.
+    pub fn forward_masked(
+        &self,
+        x: &Tensor<Q::T, Q::B>,
+        state: &mut StreamingTransformerState<Q::T, Q::B>,
+        key_padding: Option<&[Vec<bool>]>,
+    ) -> Result<Tensor<Q::T, Q::B>> {
         let mut x = x.clone();
         let (_, seq_len, _) = x.dims3()?;
         let mask = match state.layer_states.first() {
             Some(LayerAttentionState::Mimi(kv_cache)) => {
+                if key_padding.is_some() {
+                    xn::bail!("key-padding masks are not supported by the mimi attention")
+                }
                 let kv_seq_len = kv_cache.current_seq_len()?;
                 let context = kv_cache.context;
                 // Causal mask of shape (1, 1, seq_len, kv_seq_len + seq_len) with -inf in upper triangle
@@ -480,9 +534,12 @@ impl<Q: BackendQ> StreamingTransformer<Q> {
                     Tensor::from_vec(mask_data, (1, 1, seq_len, kv_seq_len + seq_len), x.device())?;
                 Some(mask)
             }
-            Some(LayerAttentionState::FlowLm(kv_cache)) => {
-                Some(kv_cache.materialize_causal_mask(seq_len)?)
-            }
+            Some(LayerAttentionState::FlowLm(kv_cache)) => match key_padding {
+                None => Some(kv_cache.materialize_causal_mask(seq_len)?),
+                Some(padding) => {
+                    Some(materialize_padded_causal_mask(kv_cache, seq_len, padding, x.device())?)
+                }
+            },
             _ => None,
         };
         let offset = state
@@ -493,8 +550,42 @@ impl<Q: BackendQ> StreamingTransformer<Q> {
                 LayerAttentionState::FlowLm(mha_state) => mha_state.current_end,
             })
             .unwrap_or(0);
-        let rope =
-            RotaryEmbedding::new(self.head_dim, offset, seq_len, self.max_period, x.device())?;
+        let rope = match key_padding {
+            None => {
+                RotaryEmbedding::new(self.head_dim, offset, seq_len, self.max_period, x.device())?
+            }
+            Some(padding) => {
+                // Each item advances its rope position only on non-padding steps, so the
+                // positions seen by an item are exactly the ones of an unpadded run.
+                // Padding steps reuse the upcoming position; they are excluded from the
+                // attention by the mask so their rotation does not matter.
+                let mut positions = Vec::with_capacity(padding.len());
+                for row in padding.iter() {
+                    if row.len() != offset + seq_len {
+                        xn::bail!(
+                            "unexpected key-padding length {} for {} positions",
+                            row.len(),
+                            offset + seq_len
+                        )
+                    }
+                    let mut pos = row[..offset].iter().filter(|&&p| !p).count();
+                    let mut item_positions = Vec::with_capacity(seq_len);
+                    for &is_padding in row[offset..].iter() {
+                        item_positions.push(pos);
+                        if !is_padding {
+                            pos += 1;
+                        }
+                    }
+                    positions.push(item_positions);
+                }
+                RotaryEmbedding::new_per_item(
+                    self.head_dim,
+                    &positions,
+                    self.max_period,
+                    x.device(),
+                )?
+            }
+        };
         for (layer, layer_state) in self.layers.iter().zip(state.layer_states.iter_mut()) {
             x = layer.forward(&x, &rope, layer_state, mask.as_ref())?;
         }

--- a/ptts/src/tts_model.rs
+++ b/ptts/src/tts_model.rs
@@ -218,6 +218,46 @@ impl<Q: BackendQ> TTSModel<Q> {
         Ok(())
     }
 
+    /// Run flow LM step with a batch of text prompts. Increments state.
+    ///
+    /// Each prompt is left-padded with the conditioner's padding token up to the
+    /// longest prompt in the batch, so the state must have been initialized with
+    /// `batch_size == text_tokens.len()`. The padded positions are excluded from the
+    /// attention through a key-padding mask carried by the state, and left padding
+    /// (rather than right) keeps the relative positions between the text tokens and the
+    /// generated frames identical to the unpadded case.
+    pub fn prompt_text_batch(
+        &self,
+        state: &mut TTSState<Q>,
+        text_tokens: &[Vec<u32>],
+    ) -> Result<()> {
+        let batch_size = text_tokens.len();
+        let pad_id = self.flow_lm.conditioner.pad_token_id();
+        let max_len = text_tokens.iter().map(|t| t.len()).max().unwrap_or(0);
+        let mut padded = Vec::with_capacity(batch_size * max_len);
+        let mut new_padding = Vec::with_capacity(batch_size);
+        for tokens in text_tokens.iter() {
+            let pad_len = max_len - tokens.len();
+            padded.extend(std::iter::repeat_n(pad_id, pad_len));
+            padded.extend_from_slice(tokens);
+            let mut padding_row = vec![true; pad_len];
+            padding_row.extend(std::iter::repeat_n(false, tokens.len()));
+            new_padding.push(padding_row);
+        }
+        let text_embeddings = self.flow_lm.conditioner.embed_tokens(&padded)?;
+        let output_dim = self.flow_lm.conditioner.output_dim;
+        let text_embeddings = text_embeddings.reshape((batch_size, max_len, output_dim))?;
+        let dev = text_embeddings.device();
+        let empty_latents = Tensor::zeros((batch_size, 0, self.flow_lm.ldim), dev)?;
+        self.run_backbone_and_increment_padded(
+            state,
+            &text_embeddings,
+            &empty_latents,
+            Some(&new_padding),
+        )?;
+        Ok(())
+    }
+
     pub fn prompt_text_null(&self, state: &mut TTSState<Q>) -> Result<()> {
         let empty_text = match self.flow_lm.conditioner.learnt_padding() {
             None => xn::bail!("Model does not support null text prompt"),
@@ -236,8 +276,9 @@ impl<Q: BackendQ> TTSModel<Q> {
         audio_conditioning: &Tensor<Q::T, Q::B>,
     ) -> Result<()> {
         let dev = audio_conditioning.device();
-        let empty_text = Tensor::zeros((1, 0, self.flow_lm.conditioner.dim), dev)?;
-        let empty_latents = Tensor::zeros((1, 0, self.flow_lm.ldim), dev)?;
+        let (b, _, _) = audio_conditioning.dims3()?;
+        let empty_text = Tensor::zeros((b, 0, self.flow_lm.conditioner.dim), dev)?;
+        let empty_latents = Tensor::zeros((b, 0, self.flow_lm.ldim), dev)?;
         let text_embeddings = Tensor::cat(&[&empty_text, audio_conditioning], 1)?;
         self.run_backbone_and_increment(state, &text_embeddings, &empty_latents)?;
         Ok(())
@@ -252,10 +293,24 @@ impl<Q: BackendQ> TTSModel<Q> {
         backbone_input: &Tensor<Q::T, Q::B>,
         rng: &mut impl crate::flow_lm::Rng,
     ) -> Result<(Tensor<Q::T, Q::B>, bool)> {
-        let dev = backbone_input.device();
-        let empty_text = Tensor::zeros((1, 0, self.flow_lm.conditioner.dim), dev)?;
+        let (latent, is_eos) = self.generate_step_batch(state, backbone_input, rng)?;
+        Ok((latent, is_eos[0]))
+    }
 
-        let (latent, is_eos) = self.flow_lm.sample_next_latent(
+    /// Run one autoregressive generation step on a batch.
+    /// Returns (next_latent [B, 1, ldim], per-item is_eos flags of length B).
+    #[allow(clippy::type_complexity)]
+    pub fn generate_step_batch(
+        &self,
+        state: &mut TTSState<Q>,
+        backbone_input: &Tensor<Q::T, Q::B>,
+        rng: &mut impl crate::flow_lm::Rng,
+    ) -> Result<(Tensor<Q::T, Q::B>, Vec<bool>)> {
+        let dev = backbone_input.device();
+        let (b, _, _) = backbone_input.dims3()?;
+        let empty_text = Tensor::zeros((b, 0, self.flow_lm.conditioner.dim), dev)?;
+
+        let (latent, is_eos) = self.flow_lm.sample_next_latents(
             backbone_input,
             &empty_text,
             &mut state.flow_lm_state,
@@ -277,7 +332,8 @@ impl<Q: BackendQ> TTSModel<Q> {
         rng: &mut impl crate::flow_lm::Rng,
     ) -> Result<(Tensor<Q::T, Q::B>, bool)> {
         let dev = backbone_input.device();
-        let empty_text = Tensor::zeros((1, 0, self.flow_lm.conditioner.dim), dev)?;
+        let (b, _, _) = backbone_input.dims3()?;
+        let empty_text = Tensor::zeros((b, 0, self.flow_lm.conditioner.dim), dev)?;
 
         let (latent, is_eos) = self.flow_lm.sample_next_latent_cfg(
             backbone_input,
@@ -325,10 +381,29 @@ impl<Q: BackendQ> TTSModel<Q> {
         text_embeddings: &Tensor<Q::T, Q::B>,
         backbone_input_latents: &Tensor<Q::T, Q::B>,
     ) -> Result<()> {
+        self.run_backbone_and_increment_padded(state, text_embeddings, backbone_input_latents, None)
+    }
+
+    /// Same as `run_backbone_and_increment`, with `new_padding[b][p]` flagging which of
+    /// the new positions hold padding that must not be attended to afterwards.
+    fn run_backbone_and_increment_padded(
+        &self,
+        state: &mut TTSState<Q>,
+        text_embeddings: &Tensor<Q::T, Q::B>,
+        backbone_input_latents: &Tensor<Q::T, Q::B>,
+        new_padding: Option<&[Vec<bool>]>,
+    ) -> Result<()> {
         let input = self.flow_lm.input_linear.forward(backbone_input_latents)?;
         let input = Tensor::cat(&[text_embeddings, &input], 1)?;
-        let _out =
-            self.flow_lm.transformer.forward(&input, &mut state.flow_lm_state.transformer_state)?;
+        match new_padding {
+            Some(new_padding) => state.flow_lm_state.extend_padding(new_padding)?,
+            None => state.flow_lm_state.extend_valid(input.dim(1usize)?),
+        }
+        let _out = self.flow_lm.transformer.forward_masked(
+            &input,
+            &mut state.flow_lm_state.transformer_state,
+            state.flow_lm_state.padding.as_deref(),
+        )?;
         Ok(())
     }
 


### PR DESCRIPTION
## What

Batched generation for the TTS pipeline, plus a `batch` subcommand in the `pocket_tts` example:

```
cargo run --release --example pocket_tts --features sp -- batch queries.jsonl -b 32
```

with one `{"text": "...", "output": "optional/path.wav"}` per input line. Queries are split into sentence chunks, chunks of similar estimated length are grouped into batches, and each query's chunks are concatenated back into a single wav.

## Library changes

- `TTSModel::prompt_text_batch` — prompts a batch of texts, left-padded to a common length with the conditioner's padding token (the reserved `n_bins` embedding row when the checkpoint has no learnt padding, matching the reference implementation's pad index).
- `TTSModel::generate_step_batch` / `FlowLM::sample_next_latents` — per-item EOS flags; the single-item entry points delegate to them.
- **Key-padding attention masks**: `FlowLMState` tracks per-item padding flags and `StreamingTransformer::forward_masked` combines them with the causal mask (`[B, 1, q, K]`), so padded positions are never attended to. Streams without padding keep the existing mask path.
- **Per-item rope positions**: each item advances its rope position only on its own non-padding steps (via batched `rope_i` cos/sin tables), so a padded item sees exactly the position geometry of an unpadded run.
- The flow-lm attention now passes contiguous operands to the batched matmuls — a workaround for strided batched matmul corrupting batch rows past the first in xn ≤ 0.1.21, fixed upstream in LaurentMazare/xn#50. These `contiguous()` calls can be dropped once a release with that fix ships.
- In the example, Mimi decoding is split across up to four decode threads (`--decode-threads`), each owning the streaming state of a contiguous batch slice; the single-threaded decoder was the pipeline bottleneck past batch 4 on CPU.

## Correctness

Verified with a cycling `--rng-values` file so every item draws identical noise and a batched item can be compared sample-by-sample against its own solo run:

- A batch of identical texts reproduces the solo output bit-for-bit per item (max sample diff 27/32768 ≈ f32 accumulation noise).
- In mixed-length batches every item — padded or not — ends on exactly the same frame as its solo run; waveform SNR vs the solo reference is 36–70 dB.

## Throughput

RTF (seconds of audio per wall second) against batch size 1, on 16 unique sentences repeated:

| device | baseline | peak | speedup |
|---|---|---|---|
| CPU (Ryzen 7950X, f32, 64 queries) | 5.15 | 10.8 @ batch 32 | 2.1× |
| CUDA (RTX 4080 SUPER 16 GB, bf16, 256 queries) | 28.5 | 335 @ batch 64 | 11.8× |

Known headroom: masks/rope tables are rebuilt host-side every step (visible in the CUDA step time at batch 128), batch efficiency drops when batches mix lengths (all items step until the longest finishes), and `--cfg-coef` is rejected in batch mode.

`cargo check` / `test` / `fmt --check` / `clippy -D warnings` (workspace and `--features sp` examples) pass; `ptts-pyo3` builds unchanged.
