### PR TITLE
Default the pocket_tts Metal backend to bf16

### DIFF
--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -245,7 +245,7 @@ fn main() -> Result<()> {
         } else {
             tracing::info!("using metal backend");
             let dev = xn::metal_backend::Device::new(0)?;
-            run_for_device::<xn::Unquantized<f32, _>>(args, dev)?;
+            run_for_device::<xn::Unquantized<half::bf16, _>>(args, dev)?;
         }
     }
     #[cfg(not(any(feature = "cuda", feature = "vulkan", feature = "metal")))]


### PR DESCRIPTION
## Summary
- The Metal branch in `pocket_tts.rs` ran the flow_lm backbone in f32; the CUDA branch already defaults to bf16 unconditionally. This brings Metal to parity.
- Benchmarked on an Apple M3 Max across the batch-size sweep from `MAC_BENCHMARK.md`: bf16 cuts backbone step time by ~9-16% at batch sizes up to 32, widening to ~38% at batch 64, and drops peak RSS by roughly 30% (e.g. ~500 MB vs ~650-720 MB at batch 32). RTF improves from 45.4 to 52.9 at the batch-32 peak.
- Metal has full bf16 kernel support (gemm, rope, softmax, rms_norm); Mimi decode is unaffected since it's hardcoded to f32 independent of the backbone dtype.
- `--cpu` is untouched (still f32).

## Test plan
- [x] `cargo build --release --example pocket_tts --features sp,metal`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --example pocket_tts --features sp,metal -- -D warnings`
- [x] Smoke test: default Metal run now logs bf16-level peak RSS (~449 MB vs ~650 MB before) and produces valid, correctly-lengthed audio
- [x] `--cpu` path re-verified unaffected (f32, ~655 MB peak RSS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jdKSszTjHvxJD9a6DSgR8