### PR TITLE
Support learned BOS before voice conditioning

### DIFF
--- a/ptts/src/flow_lm.rs
+++ b/ptts/src/flow_lm.rs
@@ -48,6 +48,9 @@ pub struct FlowLMConfig {
     pub flow_dim: usize,
     pub flow_depth: usize,
     pub ldim: usize,
+    /// Insert the model's learned conditioning marker before a voice prompt.
+    #[serde(default)]
+    pub insert_bos_before_voice: bool,
 }
 
 /// Transformer-based flow language model.
@@ -59,6 +62,7 @@ pub struct FlowLM<Q: BackendQ> {
     pub emb_std: Tensor<Q::T, Q::B>,
     pub emb_mean: Tensor<Q::T, Q::B>,
     bos_emb: Tensor<Q::T, Q::B>,
+    bos_before_voice: Option<Tensor<Q::T, Q::B>>,
     pub input_linear: Linear<Q::T, Q::B>,
     out_norm_weight: Tensor<Q::T, Q::B>,
     out_norm_bias: Tensor<Q::T, Q::B>,
@@ -121,6 +125,10 @@ impl<Q: BackendQ> FlowLM<Q> {
         let emb_std = vb.tensor("emb_std", (cfg.ldim,))?;
         let emb_mean = vb.tensor("emb_mean", (cfg.ldim,))?;
         let bos_emb = vb.tensor("bos_emb", (cfg.ldim,))?;
+        let bos_before_voice = cfg
+            .insert_bos_before_voice
+            .then(|| vb.tensor("bos_before_voice", (1, 1, cfg.d_model)))
+            .transpose()?;
         let input_linear = Linear::load(vb.pp("input_linear"), cfg.ldim, cfg.d_model)?;
         let out_norm_weight = vb.pp("out_norm").tensor("weight", (cfg.d_model,))?;
         let out_norm_bias = vb.pp("out_norm").tensor("bias", (cfg.d_model,))?;
@@ -134,6 +142,7 @@ impl<Q: BackendQ> FlowLM<Q> {
             emb_std,
             emb_mean,
             bos_emb,
+            bos_before_voice,
             input_linear,
             out_norm_weight,
             out_norm_bias,
@@ -146,6 +155,14 @@ impl<Q: BackendQ> FlowLM<Q> {
     pub fn init_state(&self, batch_size: usize, sequence_length: usize) -> Result<FlowLMState<Q>> {
         let transformer_state = self.transformer.init_state(batch_size, sequence_length)?;
         Ok(FlowLMState { transformer_state })
+    }
+
+    /// Prepend the learned voice marker when this checkpoint requires one.
+    pub(crate) fn prepare_audio_conditioning(
+        &self,
+        audio_conditioning: &Tensor<Q::T, Q::B>,
+    ) -> Result<Tensor<Q::T, Q::B>> {
+        prepend_bos_before_voice(self.bos_before_voice.as_ref(), audio_conditioning)
     }
 
     /// Run the backbone: concat text_embeddings + input, run transformer, strip prefix.
@@ -254,5 +271,76 @@ impl<Q: BackendQ> FlowLM<Q> {
             }
         }
         Tensor::from_vec(out_data, sequence.shape().clone(), sequence.device())
+    }
+}
+
+fn prepend_bos_before_voice<T: WithDTypeF, B: Backend>(
+    bos: Option<&Tensor<T, B>>,
+    audio_conditioning: &Tensor<T, B>,
+) -> Result<Tensor<T, B>> {
+    let Some(bos) = bos else { return Ok(audio_conditioning.clone()) };
+    let (batch_size, _, dim) = audio_conditioning.dims3()?;
+    let bos = bos.expand((batch_size, 1, dim))?.contiguous()?;
+    Tensor::cat(&[&bos, audio_conditioning], 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FlowLMConfig, prepend_bos_before_voice};
+    use serde_json::json;
+    use xn::{CPU, Tensor};
+
+    fn config_json() -> serde_json::Value {
+        json!({
+            "d_model": 1024,
+            "num_heads": 16,
+            "num_layers": 6,
+            "dim_feedforward": 4096,
+            "max_period": 10000.0,
+            "n_bins": 4000,
+            "lut_dim": 1024,
+            "flow_dim": 512,
+            "flow_depth": 6,
+            "ldim": 32
+        })
+    }
+
+    #[test]
+    fn missing_bos_config_preserves_legacy_behavior() {
+        let config: FlowLMConfig = serde_json::from_value(config_json()).unwrap();
+
+        assert!(!config.insert_bos_before_voice);
+    }
+
+    #[test]
+    fn bos_config_can_be_enabled() {
+        let mut value = config_json();
+        value["insert_bos_before_voice"] = json!(true);
+        let config: FlowLMConfig = serde_json::from_value(value).unwrap();
+
+        assert!(config.insert_bos_before_voice);
+    }
+
+    #[test]
+    fn audio_conditioning_is_unchanged_without_bos() {
+        let audio = Tensor::from_vec(vec![1_f32, 2., 3., 4.], (1, 2, 2), &CPU).unwrap();
+        let prepared = prepend_bos_before_voice(None, &audio).unwrap();
+
+        assert_eq!(prepared.dims(), &[1, 2, 2]);
+        assert_eq!(prepared.to_vec().unwrap(), vec![1., 2., 3., 4.]);
+    }
+
+    #[test]
+    fn bos_is_prepended_to_each_audio_conditioning_batch() {
+        let bos = Tensor::from_vec(vec![9_f32, 8.], (1, 1, 2), &CPU).unwrap();
+        let audio =
+            Tensor::from_vec(vec![1_f32, 2., 3., 4., 5., 6., 7., 8.], (2, 2, 2), &CPU).unwrap();
+        let prepared = prepend_bos_before_voice(Some(&bos), &audio).unwrap();
+
+        assert_eq!(prepared.dims(), &[2, 3, 2]);
+        assert_eq!(
+            prepared.to_vec().unwrap(),
+            vec![9., 8., 1., 2., 3., 4., 9., 8., 5., 6., 7., 8.]
+        );
     }
 }

--- a/ptts/src/tts_model.rs
+++ b/ptts/src/tts_model.rs
@@ -90,6 +90,7 @@ impl TTSConfig {
                 flow_dim: 512,
                 flow_depth: 6,
                 ldim: 32,
+                insert_bos_before_voice: false,
             },
             mimi: MimiConfig {
                 channels: 1,
@@ -235,10 +236,11 @@ impl<Q: BackendQ> TTSModel<Q> {
         state: &mut TTSState<Q>,
         audio_conditioning: &Tensor<Q::T, Q::B>,
     ) -> Result<()> {
+        let audio_conditioning = self.flow_lm.prepare_audio_conditioning(audio_conditioning)?;
         let dev = audio_conditioning.device();
         let empty_text = Tensor::zeros((1, 0, self.flow_lm.conditioner.dim), dev)?;
         let empty_latents = Tensor::zeros((1, 0, self.flow_lm.ldim), dev)?;
-        let text_embeddings = Tensor::cat(&[&empty_text, audio_conditioning], 1)?;
+        let text_embeddings = Tensor::cat(&[&empty_text, &audio_conditioning], 1)?;
         self.run_backbone_and_increment(state, &text_embeddings, &empty_latents)?;
         Ok(())
     }


### PR DESCRIPTION
## What changed

- add an opt-in `insert_bos_before_voice` FlowLM configuration field
- load the checkpoint's learned `bos_before_voice` tensor when enabled
- prepend that marker to voice conditioning before priming the model
- keep configurations that omit the field on the existing path

## Why

Current Pocket TTS April 2026 and multilingual configurations use a learned BOS marker before voice conditioning. Without this model semantic, those checkpoints cannot be represented faithfully by XN-PTTS. The January 2026 model does not use the marker, so the new field defaults to `false` for backward compatibility.

## Validation

- `cargo test -p ptts`
- `cargo clippy -p ptts --all-targets --features sp,accelerate -- -D warnings`
- `cargo fmt --all -- --check`
- real January Q8 synthesis before and after the change produced byte-identical 180,480-byte PCM (`359243cf7a0d02984106f49b13002504b19747fe808403729f93b387972d3c9b`)

The unit tests use synthetic tensors; no gated model assets are included.
