### PR TITLE
Add support for a separate speaker Mimi encoder.

### DIFF
--- a/ptts-pyo3/src/lib.rs
+++ b/ptts-pyo3/src/lib.rs
@@ -1,4 +1,4 @@
-use numpy::{PyArray1, PyReadonlyArray1};
+use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArrayDyn, PyUntypedArrayMethods};
 use ptts::tts_model::{MimiEnc, TTSConfig, TTSModel, TTSState};
 use pyo3::prelude::*;
 use std::sync::Arc;
@@ -52,6 +52,20 @@ macro_rules! py_bail {
 const POCKET_TTS_VOICES: &[&str] =
     &["alba", "marius", "javert", "jean", "fantine", "cosette", "eponine", "azelma"];
 
+/// Flatten a numpy conditioning-embedding array of shape `[T, dim]` or `[1, T, dim]`
+/// into a contiguous `(data, T, dim)` triple.
+fn parse_embeddings(arr: &PyReadonlyArrayDyn<'_, f32>) -> PyResult<(Vec<f32>, usize, usize)> {
+    let (n_frames, dim) = match arr.shape() {
+        [t, d] => (*t, *d),
+        [1, t, d] => (*t, *d),
+        shape => {
+            py_bail!("expected embeddings of shape [T, dim] or [1, T, dim], got {shape:?}")
+        }
+    };
+    let data: Vec<f32> = arr.as_array().iter().copied().collect();
+    Ok((data, n_frames, dim))
+}
+
 struct ModelB<Q: BackendQ> {
     inner: Arc<TTSModel<Q>>,
     mimi_enc: Option<MimiEnc<Q>>,
@@ -59,6 +73,7 @@ struct ModelB<Q: BackendQ> {
     audio_prompt_min_duration: f32,
     audio_prompt_max_duration: f32,
     cfg_null_audio_empty: bool,
+    speaker_sample_rate: usize,
 }
 
 impl<Q: BackendQ> ModelB<Q> {
@@ -68,7 +83,7 @@ impl<Q: BackendQ> ModelB<Q> {
         cfg_coef: Option<f32>,
         max_seq_len: usize,
     ) -> xn::Result<ModelStateB<Q>> {
-        let sample_rate = self.inner.sample_rate();
+        let sample_rate = self.speaker_sample_rate;
         let mimi_enc = match self.mimi_enc.as_ref() {
             Some(enc) => enc,
             None => xn::bail!("model does not support audio prompts"),
@@ -120,6 +135,46 @@ impl<Q: BackendQ> ModelB<Q> {
         let mut state = self.inner.init_flow_lm_state(1, max_seq_len)?;
         self.inner.prompt_audio(&mut state, voice_emb)?;
         Ok(ModelStateB { model: Arc::clone(&self.inner), state, cfg_state: None })
+    }
+
+    /// Build a generation state from a precomputed conditioning embedding (the mimi
+    /// encoder output, shape `[T, dim]`). When `cfg_coef` is set, a CFG null state is
+    /// also prepared; if the model uses non-empty null audio conditioning, the encoder
+    /// output of silence must be supplied via `null_embeddings`.
+    fn get_state_for_embeddings(
+        &self,
+        embeddings: Vec<f32>,
+        n_frames: usize,
+        dim: usize,
+        cfg_coef: Option<f32>,
+        null_embeddings: Option<(Vec<f32>, usize, usize)>,
+        max_seq_len: usize,
+    ) -> xn::Result<ModelStateB<Q>> {
+        let dev = self.inner.device();
+        let emb = Tensor::from_vec(embeddings, (1, n_frames, dim), dev)?.to::<Q::T>()?;
+        let mut state = self.inner.init_flow_lm_state(1, max_seq_len)?;
+        self.inner.prompt_audio(&mut state, &emb)?;
+        let cfg_state = if let Some(cfg_coef) = cfg_coef {
+            let mut null_state = self.inner.init_flow_lm_state(1, max_seq_len)?;
+            if !self.cfg_null_audio_empty {
+                match null_embeddings {
+                    Some((null, n, d)) => {
+                        let null_emb = Tensor::from_vec(null, (1, n, d), dev)?.to::<Q::T>()?;
+                        self.inner.prompt_audio(&mut null_state, &null_emb)?;
+                    }
+                    None => xn::bail!(
+                        "this model uses non-empty CFG null audio conditioning \
+                         (cfg_null_audio_empty=false); pass `null_embeddings` (e.g. the mimi \
+                         encoder output of silence of the same length) to use CFG with \
+                         precomputed embeddings"
+                    ),
+                }
+            }
+            Some((cfg_coef, null_state))
+        } else {
+            None
+        };
+        Ok(ModelStateB { model: Arc::clone(&self.inner), state, cfg_state })
     }
 
     fn voices(&self) -> Vec<String> {
@@ -240,6 +295,39 @@ impl Model {
     fn get_state_for_voice(&self, voice: &str, max_seq_len: usize) -> PyResult<ModelState> {
         let inner =
             on_model_to_state!(&self.0, |m| m.get_state_for_voice(voice, max_seq_len).w()?);
+        Ok(ModelState(inner))
+    }
+
+    /// Build a generation state from a precomputed conditioning embedding (the mimi
+    /// encoder output), with optional classifier-free guidance.
+    ///
+    /// `embeddings` must have shape `[T, dim]` or `[1, T, dim]`. To use CFG, pass
+    /// `cfg_coef`; for models with non-empty null audio conditioning, also pass
+    /// `null_embeddings` (the encoder output of silence of matching length).
+    #[pyo3(signature = (embeddings, cfg_coef=None, null_embeddings=None, max_seq_len=2048))]
+    fn get_state_for_embeddings(
+        &self,
+        embeddings: PyReadonlyArrayDyn<'_, f32>,
+        cfg_coef: Option<f32>,
+        null_embeddings: Option<PyReadonlyArrayDyn<'_, f32>>,
+        max_seq_len: usize,
+    ) -> PyResult<ModelState> {
+        let (embeddings, n_frames, dim) = parse_embeddings(&embeddings)?;
+        let null = match null_embeddings.as_ref() {
+            Some(arr) => {
+                let (data, n, d) = parse_embeddings(arr)?;
+                if d != dim {
+                    py_bail!(
+                        "null_embeddings last dim ({d}) must match embeddings last dim ({dim})"
+                    );
+                }
+                Some((data, n, d))
+            }
+            None => None,
+        };
+        let inner = on_model_to_state!(&self.0, |m| m
+            .get_state_for_embeddings(embeddings, n_frames, dim, cfg_coef, null, max_seq_len)
+            .w()?);
         Ok(ModelState(inner))
     }
 
@@ -938,11 +1026,11 @@ fn load_model_<Q: BackendQ>(
     } else {
         model
     };
-    let mimi_enc = if vb.contains("mimi.encoder.model.0.conv.weight") {
-        Some(MimiEnc::<Q>::load(&vb, &cfg)?)
-    } else {
-        None
-    };
+    // Probe under the speaker prefix: a dedicated speaker codec ships its
+    // encoder as `<speaker_mimi.prefix>.encoder.*` with no `mimi.encoder.*`.
+    let enc_probe = format!("{}.encoder.model.0.conv.weight", cfg.speaker_mimi_prefix());
+    let mimi_enc =
+        if vb.contains(&enc_probe) { Some(MimiEnc::<Q>::load(&vb, &cfg)?) } else { None };
     vb.check_all_used_with_ignore(|v| {
         v == "flow_lm.condition_provider.conditioners.speaker_wavs.learnt_padding"
             || v.starts_with("mimi.quantizer")
@@ -955,6 +1043,7 @@ fn load_model_<Q: BackendQ>(
         audio_prompt_min_duration: cfg.audio_prompt_min_duration,
         audio_prompt_max_duration: cfg.audio_prompt_max_duration,
         cfg_null_audio_empty: cfg.cfg_null_audio_empty,
+        speaker_sample_rate: cfg.speaker_mimi_cfg().sample_rate,
     })
 }
 

--- a/ptts/examples/create_voice.rs
+++ b/ptts/examples/create_voice.rs
@@ -86,23 +86,23 @@ fn run(args: Args) -> Result<()> {
         (cfg, model_path)
     };
     let model_ext = cfg.model_ext();
-    let mimi_sample_rate = cfg.mimi.sample_rate;
     tracing::info!(?model_ext, "model extension");
     tracing::info!("loading voice from audio file {}", args.input);
 
+    let speaker_sr = cfg.speaker_mimi_cfg().sample_rate;
     let (mut pcm, sample_rate) = audio_helpers::pcm_decode(&args.input)?;
     ptts::utils::normalize_loudness(&mut pcm, sample_rate)?;
     let sample_rate = sample_rate as usize;
-    let pcm = if sample_rate != mimi_sample_rate {
-        audio_helpers::resample(&pcm, sample_rate, mimi_sample_rate)?
+    let pcm = if sample_rate != speaker_sr {
+        audio_helpers::resample(&pcm, sample_rate, speaker_sr)?
     } else {
         pcm
     };
     tracing::info!("loaded audio with {} samples", pcm.len());
     // Trim it to 10s max.
-    let pcm = if pcm.len() > mimi_sample_rate * 10 {
+    let pcm = if pcm.len() > speaker_sr * 10 {
         tracing::info!("trimming audio to 10 seconds");
-        pcm[..mimi_sample_rate * 10].to_vec()
+        pcm[..speaker_sr * 10].to_vec()
     } else {
         pcm
     };

--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -466,16 +466,17 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
             }
             Voice::Audio(path) => {
                 tracing::info!("loading voice from audio file {}", path);
+                let speaker_sr = cfg.speaker_mimi_cfg().sample_rate;
                 let (mut pcm, sample_rate) = audio_helpers::pcm_decode(&path)?;
                 ptts::utils::normalize_loudness(&mut pcm, sample_rate)?;
                 let sample_rate = sample_rate as usize;
-                let pcm = if sample_rate != cfg.mimi.sample_rate {
-                    audio_helpers::resample(&pcm, sample_rate, cfg.mimi.sample_rate)?
+                let pcm = if sample_rate != speaker_sr {
+                    audio_helpers::resample(&pcm, sample_rate, speaker_sr)?
                 } else {
                     pcm
                 };
                 tracing::info!("loaded audio with {} samples", pcm.len());
-                let sr = cfg.mimi.sample_rate as f32;
+                let sr = speaker_sr as f32;
                 let min_len = (sr * cfg.audio_prompt_min_duration).round() as usize;
                 let max_len = (sr * cfg.audio_prompt_max_duration).round() as usize;
                 let pcm = if pcm.len() > max_len {

--- a/ptts/src/tts_model.rs
+++ b/ptts/src/tts_model.rs
@@ -48,6 +48,16 @@ pub struct ModelId {
     pub mimi_epoch: usize,
 }
 
+/// Optional separate Mimi codec used only for speaker (voice-prompt) encoding.
+/// When set, `MimiEnc` loads its encoder weights from `prefix` and uses
+/// `mimi` as the codec config, instead of the main `TTSConfig.mimi`.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SpeakerMimiConfig {
+    /// Weight-name prefix for the speaker mimi (e.g. `"speaker_mimi"`).
+    pub prefix: String,
+    pub mimi: MimiConfig,
+}
+
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct TTSConfig {
     pub flow_lm: FlowLMConfig,
@@ -74,6 +84,10 @@ pub struct TTSConfig {
     /// real audio prompt's length, which preserves the historical behavior.
     #[serde(default)]
     pub cfg_null_audio_empty: bool,
+    /// Optional, when set the speaker encoder loads from this prefix using
+    /// this dedicated `MimiConfig` rather than the main `mimi` codec.
+    #[serde(default)]
+    pub speaker_mimi: Option<SpeakerMimiConfig>,
 }
 
 impl TTSConfig {
@@ -129,11 +143,29 @@ impl TTSConfig {
             audio_prompt_min_duration: 10.0,
             audio_prompt_max_duration: 10.0,
             cfg_null_audio_empty: false,
+            speaker_mimi: None,
         }
     }
 
     pub fn model_ext(&self) -> Option<String> {
         self.model_id.as_ref().map(|id| format!("{}@{}", id.sig, id.epoch))
+    }
+
+    /// Returns the `MimiConfig` used to encode the voice prompt — the
+    /// dedicated `speaker_mimi.mimi` if set, otherwise the main `mimi`.
+    pub fn speaker_mimi_cfg(&self) -> &MimiConfig {
+        match self.speaker_mimi.as_ref() {
+            Some(s) => &s.mimi,
+            None => &self.mimi,
+        }
+    }
+
+    /// Returns the weight-name prefix used to load the speaker encoder.
+    pub fn speaker_mimi_prefix(&self) -> &str {
+        match self.speaker_mimi.as_ref() {
+            Some(s) => s.prefix.as_str(),
+            None => "mimi",
+        }
     }
 }
 
@@ -344,10 +376,11 @@ pub struct MimiEnc<Q: BackendQ> {
 
 impl<Q: BackendQ> MimiEnc<Q> {
     pub fn load(vb: &Path<Q::B>, cfg: &TTSConfig) -> Result<Self> {
-        let mimi = MimiEncoder::load(&vb.pp("mimi"), &cfg.mimi)?;
+        let mimi_cfg = cfg.speaker_mimi_cfg();
+        let mimi = MimiEncoder::load(&vb.pp(cfg.speaker_mimi_prefix()), mimi_cfg)?;
         let speaker_proj = if vb.contains("flow_lm.speaker_proj_weight") {
             let weights = vb
-                .tensor("flow_lm.speaker_proj_weight", (cfg.flow_lm.d_model, cfg.mimi.dimension))?;
+                .tensor("flow_lm.speaker_proj_weight", (cfg.flow_lm.d_model, mimi_cfg.dimension))?;
             Some(Linear::new(weights))
         } else {
             None


### PR DESCRIPTION
TTSConfig gains an optional speaker_mimi section (weight-name prefix + dedicated MimiConfig): when set, the voice-prompt encoder loads from that prefix and voice prompts are resampled at the speaker codec's sample rate rather than the output codec's. The pyo3 bindings also gain get_state_for_embeddings to build a generation state directly from a precomputed conditioning embedding, with CFG null_embeddings support.