### PR TITLE
Add a `bench` example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Cargo workspace (resolver "3", edition 2024) with three members:
 
-- `ptts/` — core TTS library. Pure Rust, depends on the `xn` tensor/nn crate. Two examples live under `ptts/examples/`: `pocket_tts` (end-to-end CLI; requires the `sp` feature for SentencePiece) and `quantize` (safetensors → GGUF converter that selectively quantizes `flow_lm.transformer.layers.*` weights).
+- `ptts/` — core TTS library. Pure Rust, depends on the `xn` tensor/nn crate. Examples live under `ptts/examples/`: `pocket_tts` (end-to-end CLI) and `bench` (benchmark harness) both require the `sp` feature for SentencePiece; `quantize` (safetensors → GGUF converter that selectively quantizes `flow_lm.transformer.layers.*` weights) and `create_voice` (voice embeddings from audio samples) do not.
 - `ptts-pyo3/` — PyO3 bindings exposing `TTSModel` to Python. Built with maturin; the cdylib is named `ptts`. Has its own `pyproject.toml` and `uv.lock`.
 - `ptts-wasm/` — browser build via `wasm-bindgen` / `wasm-pack`. Ships a demo in `ptts-wasm/www/` (`index.html` + `worker.js`).
 
@@ -27,7 +27,7 @@ CI deletes `.cargo/config.toml` before building because it pins `target-cpu=nati
 
 Cargo features that gate optional functionality:
 
-- `ptts`: `sp` (SentencePiece tokenizer, required by the `pocket_tts` example), `cuda`, `accelerate`.
+- `ptts`: `sp` (SentencePiece tokenizer, required by the `pocket_tts` and `bench` examples), `cuda`, `accelerate`.
 - `ptts-pyo3`: `cuda`, `accelerate` (each forwards to both `xn/*` and `ptts/*`).
 
 Run the CLI example:
@@ -37,6 +37,16 @@ cargo run --release --example pocket_tts --features sp -- "hello world" -o out.w
 ```
 
 It downloads weights from the `kyutai/pocket-tts` HuggingFace repo on first run. Built-in voice IDs: `alba`, `marius`, `javert`, `jean`, `fantine`, `cosette`, `eponine`, `azelma`. `--voice` also accepts a path to a 10s audio file or a precomputed voice safetensors.
+
+Benchmark a local model:
+
+```
+cargo run --release --features sp,accelerate --example bench -- \
+  --model model/model.q8.gguf --config model/config.json --quant q8 \
+  --voice voices/freya.safetensors --threads 8 --iters 20
+```
+
+`bench` takes explicit paths and a precomputed voice embedding, never downloads, and reports time-to-first-audio, per-frame time, total generate time and RTF over `--iters` runs. Model load and voice conditioning are timed once and excluded from the statistics. It decodes each frame on the generating thread instead of overlapping Mimi with the next frame's sampling as `pocket_tts` does, so per-frame times attribute sampling and decoding to the frame that caused them and its RTF reads lower than `pocket_tts` for the same weights. `--threads` defaults to xn's one-per-logical-core, which is usually too many for a single autoregressive stream. For profiling rather than measuring, `pocket_tts --chrome-tracing` writes a Chrome trace for https://ui.perfetto.dev.
 
 ## WASM build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Cargo workspace (resolver "3", edition 2024) with three members:
 
-- `ptts/` — core TTS library. Pure Rust, depends on the `xn` tensor/nn crate. Examples live under `ptts/examples/`: `pocket_tts` (end-to-end CLI) and `bench` (benchmark harness) both require the `sp` feature for SentencePiece; `quantize` (safetensors → GGUF converter that selectively quantizes `flow_lm.transformer.layers.*` weights) and `create_voice` (voice embeddings from audio samples) do not.
+- `ptts/` — core TTS library. Pure Rust, depends on the `xn` tensor/nn crate. Examples live under `ptts/examples/`: `pocket_tts` (end-to-end CLI) and `bench` (benchmark harness) both require the `sp` feature for SentencePiece; `quantize` (safetensors → GGUF converter that selectively quantizes `flow_lm.transformer.layers.*` weights) and `create_voice` (voice embeddings from audio samples) do not. `audio_helpers.rs` and `model_helpers.rs` are not examples — they are shared modules each example pulls in with `#[path = "..."] mod`, so `autoexamples = false` and every example is listed explicitly in `Cargo.toml`.
 - `ptts-pyo3/` — PyO3 bindings exposing `TTSModel` to Python. Built with maturin; the cdylib is named `ptts`. Has its own `pyproject.toml` and `uv.lock`.
 - `ptts-wasm/` — browser build via `wasm-bindgen` / `wasm-pack`. Ships a demo in `ptts-wasm/www/` (`index.html` + `worker.js`).
 
@@ -46,7 +46,7 @@ cargo run --release --features sp,accelerate --example bench -- \
   --voice voices/freya.safetensors --threads 8 --iters 20
 ```
 
-`bench` takes explicit paths and a precomputed voice embedding, never downloads, and reports time-to-first-audio, per-frame time, total generate time and RTF over `--iters` runs. Model load and voice conditioning are timed once and excluded from the statistics. It decodes each frame on the generating thread instead of overlapping Mimi with the next frame's sampling as `pocket_tts` does, so per-frame times attribute sampling and decoding to the frame that caused them and its RTF reads lower than `pocket_tts` for the same weights. `--threads` defaults to xn's one-per-logical-core, which is usually too many for a single autoregressive stream. For profiling rather than measuring, `pocket_tts --chrome-tracing` writes a Chrome trace for https://ui.perfetto.dev.
+`bench` takes explicit paths and a precomputed voice embedding, never downloads, and reports time-to-first-audio, per-frame time, total generate time and RTF over `--iters` runs, excluding the one-off model load and voice conditioning. It decodes each frame on the generating thread rather than overlapping Mimi with the next frame's sampling as `pocket_tts` does, so its RTF reads lower than `pocket_tts` for the same weights — don't compare the two directly. `--threads` defaults to xn's one-per-logical-core, usually too many for a single autoregressive stream. For profiling rather than measuring, `pocket_tts --chrome-tracing` writes a Chrome trace for https://ui.perfetto.dev.
 
 ## WASM build
 

--- a/ptts/Cargo.toml
+++ b/ptts/Cargo.toml
@@ -45,6 +45,10 @@ name = "pocket_tts"
 required-features = ["sp"]
 
 [[example]]
+name = "bench"
+required-features = ["sp"]
+
+[[example]]
 name = "quantize"
 
 [[example]]

--- a/ptts/examples/bench.rs
+++ b/ptts/examples/bench.rs
@@ -2,19 +2,7 @@
 //!
 //! Loads a local model once, then generates the same utterance `--iters` times and reports
 //! time-to-first-audio, per-frame time, total generate time and RTF. Model load and voice
-//! conditioning are timed separately and excluded from the per-iteration statistics, since a
-//! server pays them once and then serves many requests.
-//!
-//! ```bash
-//! cargo run --release --features sp,accelerate --example bench -- \
-//!   --model model/model.q8.gguf --config model/config.json --quant q8 \
-//!   --voice voices/freya.safetensors --threads 8 --iters 20
-//! ```
-//!
-//! Unlike `pocket_tts` this never downloads anything and only accepts precomputed voice
-//! embeddings: it measures one specific model. Mimi decoding runs on the generating thread
-//! rather than overlapped, so a frame's time is its sampling plus its decoding; `pocket_tts`
-//! overlaps the two and will report a better RTF for the same weights.
+//! conditioning are timed separately and excluded from the per-iteration statistics.
 
 #[path = "model_helpers.rs"]
 mod model_helpers;
@@ -58,9 +46,7 @@ struct Args {
     #[arg(long, default_value_t = false)]
     cpu: bool,
 
-    /// Number of CPU threads for tensor ops. Defaults to xn's own default of one per logical
-    /// core, which is usually too many here: generation is a single autoregressive stream of
-    /// small ops, so past a few threads the coordination cost outweighs the parallelism.
+    /// Number of CPU threads for tensor ops.
     #[arg(long)]
     threads: Option<usize>,
 

--- a/ptts/examples/bench.rs
+++ b/ptts/examples/bench.rs
@@ -1,0 +1,440 @@
+//! Benchmark harness for TTS generation.
+//!
+//! Loads a local model once, then generates the same utterance `--iters` times and reports
+//! time-to-first-audio, per-frame time, total generate time and RTF. Model load and voice
+//! conditioning are timed separately and excluded from the per-iteration statistics, since a
+//! server pays them once and then serves many requests.
+//!
+//! ```bash
+//! cargo run --release --features sp,accelerate --example bench -- \
+//!   --model model/model.q8.gguf --config model/config.json --quant q8 \
+//!   --voice voices/freya.safetensors --threads 8 --iters 20
+//! ```
+//!
+//! Unlike `pocket_tts` this never downloads anything and only accepts precomputed voice
+//! embeddings: it measures one specific model. Mimi decoding runs on the generating thread
+//! rather than overlapped, so a frame's time is its sampling plus its decoding; `pocket_tts`
+//! overlaps the two and will report a better RTF for the same weights.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use ptts::tts_model::{TTSConfig, TTSModel, TTSState};
+use xn::nn::VB;
+use xn::{BackendQ, Tensor};
+
+/// Frames of Mimi decoder context, matching `pocket_tts`.
+const MIMI_CONTEXT_SIZE: usize = 250;
+/// Spare KV positions on top of what an utterance is calculated to need.
+const SEQ_BUDGET_SLACK: usize = 16;
+
+#[derive(Parser, Debug)]
+#[command(name = "bench")]
+#[command(about = "Benchmark TTS generation: TTFA, per-frame time, total runtime")]
+struct Args {
+    /// Model weights, either a safetensors file or a GGUF file (see the `quantize` example).
+    #[arg(long)]
+    model: std::path::PathBuf,
+
+    /// Model config JSON.
+    #[arg(long)]
+    config: std::path::PathBuf,
+
+    /// SentencePiece tokenizer. Defaults to `tokenizer.model` next to the config.
+    #[arg(long)]
+    tokenizer: Option<std::path::PathBuf>,
+
+    /// Precomputed voice embedding safetensors.
+    #[arg(long)]
+    voice: std::path::PathBuf,
+
+    /// Weight quantization, e.g. `q8`. Required for GGUF weights; safetensors load as f32.
+    #[arg(long)]
+    quant: Option<String>,
+
+    /// Use the cpu device even if a gpu backend is available.
+    #[arg(long, default_value_t = false)]
+    cpu: bool,
+
+    /// Number of CPU threads for tensor ops. Defaults to xn's own default of one per logical
+    /// core, which is usually too many here: generation is a single autoregressive stream of
+    /// small ops, so past a few threads the coordination cost outweighs the parallelism.
+    #[arg(long)]
+    threads: Option<usize>,
+
+    #[arg(long, short, default_value = "Hello, this is a test of the pocket TTS system.")]
+    input: String,
+
+    #[arg(long, default_value_t = 0.4)]
+    temperature: f32,
+
+    #[arg(long, default_value_t = 42)]
+    seed: u64,
+
+    /// Measured iterations.
+    #[arg(long, default_value_t = 10)]
+    iters: usize,
+
+    /// Unmeasured iterations run first, to warm caches and the thread pool.
+    #[arg(long, default_value_t = 1)]
+    warmup: usize,
+
+    /// Print a line per iteration as well as the summary.
+    #[arg(long, default_value_t = false)]
+    per_iter: bool,
+}
+
+struct SpTokenizer(sentencepiece::SentencePieceProcessor);
+
+impl ptts::Tokenizer for SpTokenizer {
+    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
+        Ok(self.0.encode(text).map_err(xn::Error::wrap)?.into_iter().map(|v| v.id).collect())
+    }
+
+    fn decode(&self, tokens: &[u32]) -> xn::Result<String> {
+        self.0.decode_piece_ids(tokens).map_err(xn::Error::wrap)
+    }
+}
+
+struct StdRng {
+    inner: rand::rngs::StdRng,
+    distr: rand_distr::Normal<f32>,
+}
+
+impl StdRng {
+    fn new(temperature: f32, seed: u64) -> Result<Self> {
+        use rand::SeedableRng;
+        let distr = rand_distr::Normal::new(0f32, temperature.sqrt())?;
+        Ok(Self { inner: rand::rngs::StdRng::seed_from_u64(seed), distr })
+    }
+}
+
+impl ptts::flow_lm::Rng for StdRng {
+    fn sample(&mut self) -> f32 {
+        use rand::Rng;
+        self.inner.sample(self.distr)
+    }
+}
+
+fn remap_key(name: &str) -> Option<String> {
+    // Skip keys we don't need
+    if name.contains("flow.w_s_t")
+        || name.contains("quantizer.vq")
+        || name.contains("quantizer.logvar_proj")
+    {
+        return None;
+    }
+
+    let mut name = name.to_string();
+
+    // Order matters: more specific replacements first
+    name = name.replace(
+        "flow_lm.condition_provider.conditioners.speaker_wavs.output_proj.weight",
+        "flow_lm.speaker_proj_weight",
+    );
+    name = name.replace(
+        "flow_lm.condition_provider.conditioners.transcript_in_segment.",
+        "flow_lm.conditioner.",
+    );
+    name = name.replace("flow_lm.backbone.", "flow_lm.transformer.");
+    name = name.replace("flow_lm.flow.", "flow_lm.flow_net.");
+    name = name.replace("mimi.model.", "mimi.");
+
+    Some(name)
+}
+
+fn load_voice_emb<Q: BackendQ>(
+    path: &std::path::Path,
+    cfg: &TTSConfig,
+    dev: &Q::B,
+) -> Result<Tensor<Q::T, Q::B>> {
+    let vb = VB::load(&[path], dev.clone())?;
+    let names = vb.tensor_names();
+    let key = names.first().context("no tensors found in voice embedding file")?;
+    let shape = vb.shape(key).context("voice tensor not found")?;
+    let dims = shape.dims().to_vec();
+    let emb: Tensor<f32, Q::B> = vb.tensor(key, shape)?;
+    // Voice files hold either [T, dim] or an already batched [1, T, dim].
+    let emb = if dims.len() == 2 { emb.reshape((1, dims[0], dims[1]))? } else { emb };
+    if let Some(model_ext) = cfg.model_ext() {
+        let file_content = std::fs::read(path)?;
+        let (_, metadata) = safetensors::SafeTensors::read_metadata(&file_content)?;
+        if let Some(metadata) = metadata.metadata()
+            && let Some(voice_model_ext) = metadata.get("model_ext")
+            && voice_model_ext.as_str() != model_ext
+        {
+            anyhow::bail!(
+                "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
+            )
+        }
+    }
+    Ok(emb.to::<Q::T>()?)
+}
+
+/// Frames an utterance of `num_tokens` tokens is allowed to generate before it is cut off.
+fn max_frames_for(num_tokens: usize) -> usize {
+    ((num_tokens as f64 / 3.0 + 2.0) * 12.5).ceil() as usize
+}
+
+/// One iteration's timings.
+struct Run {
+    /// Start of the iteration to the first audio samples, so text conditioning is included but
+    /// the voice conditioning shared by every iteration is not.
+    ttfa: Duration,
+    /// Per frame, sampling plus Mimi decoding.
+    frames: Vec<Duration>,
+    total: Duration,
+    samples: usize,
+}
+
+/// Generates the utterance once, reusing the voice-conditioned state.
+fn one<Q: BackendQ>(
+    model: &TTSModel<Q>,
+    base_state: &TTSState<Q>,
+    chunks: &[(Vec<u32>, usize)],
+    args: &Args,
+) -> Result<Run> {
+    let dev = model.device();
+    let ldim = model.flow_lm.ldim;
+    let mut rng = StdRng::new(args.temperature, args.seed)?;
+    let mut frames = Vec::new();
+    let mut ttfa = None;
+    let mut samples = 0usize;
+    let start = Instant::now();
+
+    for (tokens, frames_after_eos) in chunks.iter() {
+        let mut state = base_state.clone();
+        model.prompt_text(&mut state, tokens)?;
+        let mut mimi_state = model.init_mimi_state(1, MIMI_CONTEXT_SIZE)?;
+
+        // BOS marker: an all-NaN latent.
+        let nan: Tensor<f32, Q::B> = Tensor::from_vec(vec![f32::NAN; ldim], (1, 1, ldim), dev)?;
+        let mut prev_latent = nan.to::<Q::T>()?;
+        let mut eos_countdown: Option<usize> = None;
+
+        for _ in 0..max_frames_for(tokens.len()) {
+            let frame_start = Instant::now();
+            let (next_latent, is_eos) = model.generate_step(&mut state, &prev_latent, &mut rng)?;
+            // Decoding on this thread rather than overlapped, so the measurement attributes
+            // sampling and decoding to the frame that caused them.
+            let pcm = model.decode_latent(&next_latent, &mut mimi_state)?.to_vec()?;
+            frames.push(frame_start.elapsed());
+            if !pcm.is_empty() {
+                ttfa.get_or_insert_with(|| start.elapsed());
+                samples += pcm.len();
+            }
+
+            if is_eos && eos_countdown.is_none() {
+                eos_countdown = Some(*frames_after_eos);
+            }
+            if let Some(countdown) = eos_countdown.as_mut() {
+                if *countdown == 0 {
+                    break;
+                }
+                *countdown -= 1;
+            }
+            prev_latent = next_latent;
+        }
+    }
+
+    let total = start.elapsed();
+    let ttfa = ttfa.context("no audio produced")?;
+    Ok(Run { ttfa, frames, total, samples })
+}
+
+fn ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1e3
+}
+
+struct Stats {
+    n: usize,
+    min: f64,
+    mean: f64,
+    max: f64,
+    p50: f64,
+    p95: f64,
+}
+
+impl Stats {
+    fn of(xs: &[f64]) -> Option<Self> {
+        if xs.is_empty() {
+            return None;
+        }
+        let mut s = xs.to_vec();
+        s.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let pick = |q: f64| s[((s.len() - 1) as f64 * q).round() as usize];
+        Some(Stats {
+            n: s.len(),
+            min: s[0],
+            mean: s.iter().sum::<f64>() / s.len() as f64,
+            max: s[s.len() - 1],
+            p50: pick(0.50),
+            p95: pick(0.95),
+        })
+    }
+}
+
+fn row(label: &str, unit: &str, prec: usize, st: &Stats) {
+    println!(
+        "{label:<22} {:>5}  {:>9.*} {:>9.*} {:>9.*} {:>9.*} {:>9.*}  {unit}",
+        st.n, prec, st.min, prec, st.mean, prec, st.p50, prec, st.p95, prec, st.max
+    );
+}
+
+struct Bench<'a>(&'a Args);
+
+impl xn::WithQ for Bench<'_> {
+    fn run<Q: BackendQ>(self, dev: Q::B) -> xn::Result<()> {
+        self.bench::<Q>(dev).map_err(|e| xn::Error::msg(format!("{e:?}")))
+    }
+}
+
+impl Bench<'_> {
+    fn bench<Q: BackendQ>(&self, dev: Q::B) -> Result<()> {
+        let args = self.0;
+        let cfg: TTSConfig = serde_json::from_str(&std::fs::read_to_string(&args.config)?)
+            .with_context(|| format!("failed to read config {}", args.config.display()))?;
+        let tokenizer_path = match args.tokenizer.clone() {
+            Some(path) => path,
+            None => {
+                args.config.parent().context("config path has no parent")?.join("tokenizer.model")
+            }
+        };
+
+        let t_load = Instant::now();
+        let tokenizer_path = tokenizer_path.to_str().context("invalid tokenizer path")?;
+        let tokenizer = SpTokenizer(sentencepiece::SentencePieceProcessor::open(tokenizer_path)?);
+        let vb = if args.model.extension().and_then(|v| v.to_str()) == Some("gguf") {
+            let reader = std::io::BufReader::new(std::fs::File::open(&args.model)?);
+            VB::load_gguf_with_key_map(reader, dev.clone(), remap_key)?
+        } else {
+            VB::load_with_key_map(&[&args.model], dev.clone(), remap_key)?
+        };
+        let vb = vb.root();
+        let model: TTSModel<Q> = TTSModel::load(&vb, Box::new(tokenizer), &cfg)?;
+        vb.check_all_used_with_ignore(|v| {
+            v == "flow_lm.condition_provider.conditioners.speaker_wavs.learnt_padding"
+                || v.starts_with("mimi.quantizer")
+                || v.starts_with("mimi.encoder")
+                || v.starts_with("speaker_mimi")
+                || v == "flow_lm.speaker_proj_weight"
+                || v == "mimi.downsample.conv.conv.weight"
+        })?;
+        let voice_emb = load_voice_emb::<Q>(&args.voice, &cfg, &dev)?;
+        let load_ms = ms(t_load.elapsed());
+
+        // Tokenize up front: the loop needs the tokens anyway, and the KV cache is sized from
+        // them. Long inputs are split into sentences, as `pocket_tts` does.
+        let chunks = ptts::tts_model::split_into_best_sentences(
+            model.flow_lm.conditioner.tokenizer.as_deref().context("no tokenizer")?,
+            &args.input,
+            None,
+        )?;
+        let chunks = chunks
+            .iter()
+            .map(|chunk| {
+                let (text, frames_after_eos) = ptts::tts_model::prepare_text_prompt(chunk);
+                Ok((model.flow_lm.conditioner.tokenize(&text)?, frames_after_eos))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Condition on the voice once. Every iteration clones the resulting state, which is
+        // what a server does per request, so the measurement is of generation rather than of
+        // repeated voice conditioning.
+        let voice_len = voice_emb.dim(1usize)?;
+        let seq_budget = chunks
+            .iter()
+            .map(|(tokens, _)| voice_len + tokens.len() + max_frames_for(tokens.len()))
+            .max()
+            .unwrap_or(voice_len)
+            + SEQ_BUDGET_SLACK;
+        let t_voice = Instant::now();
+        let mut base_state = model.init_flow_lm_state(1, seq_budget)?;
+        model.prompt_audio(&mut base_state, &voice_emb)?;
+        let voice_ms = ms(t_voice.elapsed());
+
+        for _ in 0..args.warmup {
+            one(&model, &base_state, &chunks, args)?;
+        }
+        let mut runs = Vec::with_capacity(args.iters);
+        for i in 0..args.iters {
+            let r = one(&model, &base_state, &chunks, args)?;
+            if args.per_iter {
+                println!(
+                    "iter {i:>3}: total {:>8.2}ms  ttfa {:>7.2}ms  frames {:>4}",
+                    ms(r.total),
+                    ms(r.ttfa),
+                    r.frames.len()
+                );
+            }
+            runs.push(r);
+        }
+        if runs.is_empty() {
+            anyhow::bail!("--iters must be at least 1")
+        }
+
+        let audio_ms = runs[0].samples as f64 / model.sample_rate() as f64 * 1e3;
+        let totals: Vec<f64> = runs.iter().map(|r| ms(r.total)).collect();
+        let ttfas: Vec<f64> = runs.iter().map(|r| ms(r.ttfa)).collect();
+        // Pooled across iterations: per-frame variation matters more than which run it came
+        // from, and one run has too few frames for a stable tail.
+        let frames: Vec<f64> = runs.iter().flat_map(|r| r.frames.iter().copied().map(ms)).collect();
+        // Audio produced per unit of wall time, so higher is faster than realtime.
+        let rtfs: Vec<f64> = totals.iter().map(|t| audio_ms / t).collect();
+
+        println!();
+        println!(
+            "model {}  threads {}  input {} chars  audio {audio_ms:.0}ms  frames/iter {}",
+            args.model.display(),
+            xn::get_num_threads(),
+            args.input.len(),
+            runs[0].frames.len(),
+        );
+        println!("load {load_ms:.1}ms, voice conditioning {voice_ms:.1}ms (both excluded below)");
+        println!();
+        println!(
+            "{:<22} {:>5}  {:>9} {:>9} {:>9} {:>9} {:>9}",
+            "metric", "n", "min", "mean", "p50", "p95", "max"
+        );
+        if let Some(s) = Stats::of(&totals) {
+            row("total generate", "ms", 2, &s);
+        }
+        if let Some(s) = Stats::of(&ttfas) {
+            row("time to first audio", "ms", 2, &s);
+        }
+        if let Some(s) = Stats::of(&frames) {
+            row("per-frame", "ms", 3, &s);
+        }
+        if let Some(s) = Stats::of(&rtfs) {
+            row("rtf (higher is better)", "x realtime", 2, &s);
+        }
+        Ok(())
+    }
+}
+
+fn main() -> Result<()> {
+    use std::str::FromStr;
+
+    let args = Args::parse();
+    if let Some(threads) = args.threads {
+        // Must happen before the first tensor op, since it sets the size of rayon's global pool.
+        xn::set_num_threads(threads);
+    }
+    let dtype = match args.quant.as_deref() {
+        Some(quant) => xn::DTypeQ::from_str(quant)?,
+        None if args.model.extension().and_then(|v| v.to_str()) == Some("gguf") => {
+            anyhow::bail!("GGUF weights need an explicit --quant, e.g. --quant q8")
+        }
+        None => xn::DTypeQ::F32,
+    };
+    println!(
+        "avx: {}, neon: {}, simd128: {}, f16c: {}",
+        xn::with_avx(),
+        xn::with_neon(),
+        xn::with_simd128(),
+        xn::with_f16c()
+    );
+    xn::Runner::new().cpu_only(args.cpu).dtype(dtype).run(Bench(&args), 0)?;
+    Ok(())
+}

--- a/ptts/examples/bench.rs
+++ b/ptts/examples/bench.rs
@@ -16,18 +16,19 @@
 //! rather than overlapped, so a frame's time is its sampling plus its decoding; `pocket_tts`
 //! overlaps the two and will report a better RTF for the same weights.
 
+#[path = "model_helpers.rs"]
+mod model_helpers;
+
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use model_helpers::{SpTokenizer, max_frames_for};
 use ptts::tts_model::{TTSConfig, TTSModel, TTSState};
-use xn::nn::VB;
 use xn::{BackendQ, Tensor};
 
 /// Frames of Mimi decoder context, matching `pocket_tts`.
 const MIMI_CONTEXT_SIZE: usize = 250;
-/// Spare KV positions on top of what an utterance is calculated to need.
-const SEQ_BUDGET_SLACK: usize = 16;
 
 #[derive(Parser, Debug)]
 #[command(name = "bench")]
@@ -73,7 +74,7 @@ struct Args {
     seed: u64,
 
     /// Measured iterations.
-    #[arg(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10, value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..))]
     iters: usize,
 
     /// Unmeasured iterations run first, to warm caches and the thread pool.
@@ -83,18 +84,6 @@ struct Args {
     /// Print a line per iteration as well as the summary.
     #[arg(long, default_value_t = false)]
     per_iter: bool,
-}
-
-struct SpTokenizer(sentencepiece::SentencePieceProcessor);
-
-impl ptts::Tokenizer for SpTokenizer {
-    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
-        Ok(self.0.encode(text).map_err(xn::Error::wrap)?.into_iter().map(|v| v.id).collect())
-    }
-
-    fn decode(&self, tokens: &[u32]) -> xn::Result<String> {
-        self.0.decode_piece_ids(tokens).map_err(xn::Error::wrap)
-    }
 }
 
 struct StdRng {
@@ -115,66 +104,6 @@ impl ptts::flow_lm::Rng for StdRng {
         use rand::Rng;
         self.inner.sample(self.distr)
     }
-}
-
-fn remap_key(name: &str) -> Option<String> {
-    // Skip keys we don't need
-    if name.contains("flow.w_s_t")
-        || name.contains("quantizer.vq")
-        || name.contains("quantizer.logvar_proj")
-    {
-        return None;
-    }
-
-    let mut name = name.to_string();
-
-    // Order matters: more specific replacements first
-    name = name.replace(
-        "flow_lm.condition_provider.conditioners.speaker_wavs.output_proj.weight",
-        "flow_lm.speaker_proj_weight",
-    );
-    name = name.replace(
-        "flow_lm.condition_provider.conditioners.transcript_in_segment.",
-        "flow_lm.conditioner.",
-    );
-    name = name.replace("flow_lm.backbone.", "flow_lm.transformer.");
-    name = name.replace("flow_lm.flow.", "flow_lm.flow_net.");
-    name = name.replace("mimi.model.", "mimi.");
-
-    Some(name)
-}
-
-fn load_voice_emb<Q: BackendQ>(
-    path: &std::path::Path,
-    cfg: &TTSConfig,
-    dev: &Q::B,
-) -> Result<Tensor<Q::T, Q::B>> {
-    let vb = VB::load(&[path], dev.clone())?;
-    let names = vb.tensor_names();
-    let key = names.first().context("no tensors found in voice embedding file")?;
-    let shape = vb.shape(key).context("voice tensor not found")?;
-    let dims = shape.dims().to_vec();
-    let emb: Tensor<f32, Q::B> = vb.tensor(key, shape)?;
-    // Voice files hold either [T, dim] or an already batched [1, T, dim].
-    let emb = if dims.len() == 2 { emb.reshape((1, dims[0], dims[1]))? } else { emb };
-    if let Some(model_ext) = cfg.model_ext() {
-        let file_content = std::fs::read(path)?;
-        let (_, metadata) = safetensors::SafeTensors::read_metadata(&file_content)?;
-        if let Some(metadata) = metadata.metadata()
-            && let Some(voice_model_ext) = metadata.get("model_ext")
-            && voice_model_ext.as_str() != model_ext
-        {
-            anyhow::bail!(
-                "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
-            )
-        }
-    }
-    Ok(emb.to::<Q::T>()?)
-}
-
-/// Frames an utterance of `num_tokens` tokens is allowed to generate before it is cut off.
-fn max_frames_for(num_tokens: usize) -> usize {
-    ((num_tokens as f64 / 3.0 + 2.0) * 12.5).ceil() as usize
 }
 
 /// One iteration's timings.
@@ -257,21 +186,19 @@ struct Stats {
 }
 
 impl Stats {
-    fn of(xs: &[f64]) -> Option<Self> {
-        if xs.is_empty() {
-            return None;
-        }
+    /// `xs` must be non-empty; `--iters` is validated to be at least 1.
+    fn of(xs: &[f64]) -> Self {
         let mut s = xs.to_vec();
         s.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let pick = |q: f64| s[((s.len() - 1) as f64 * q).round() as usize];
-        Some(Stats {
+        Stats {
             n: s.len(),
             min: s[0],
             mean: s.iter().sum::<f64>() / s.len() as f64,
             max: s[s.len() - 1],
             p50: pick(0.50),
             p95: pick(0.95),
-        })
+        }
     }
 }
 
@@ -303,25 +230,12 @@ impl Bench<'_> {
         };
 
         let t_load = Instant::now();
-        let tokenizer_path = tokenizer_path.to_str().context("invalid tokenizer path")?;
-        let tokenizer = SpTokenizer(sentencepiece::SentencePieceProcessor::open(tokenizer_path)?);
-        let vb = if args.model.extension().and_then(|v| v.to_str()) == Some("gguf") {
-            let reader = std::io::BufReader::new(std::fs::File::open(&args.model)?);
-            VB::load_gguf_with_key_map(reader, dev.clone(), remap_key)?
-        } else {
-            VB::load_with_key_map(&[&args.model], dev.clone(), remap_key)?
-        };
-        let vb = vb.root();
+        let tokenizer = SpTokenizer::open(&tokenizer_path)?;
+        let vb = model_helpers::load_weights::<Q>(&args.model, &dev)?;
         let model: TTSModel<Q> = TTSModel::load(&vb, Box::new(tokenizer), &cfg)?;
-        vb.check_all_used_with_ignore(|v| {
-            v == "flow_lm.condition_provider.conditioners.speaker_wavs.learnt_padding"
-                || v.starts_with("mimi.quantizer")
-                || v.starts_with("mimi.encoder")
-                || v.starts_with("speaker_mimi")
-                || v == "flow_lm.speaker_proj_weight"
-                || v == "mimi.downsample.conv.conv.weight"
-        })?;
-        let voice_emb = load_voice_emb::<Q>(&args.voice, &cfg, &dev)?;
+        vb.check_all_used_with_ignore(model_helpers::is_unused_by_tts_model)?;
+        let voice_emb =
+            model_helpers::load_voice_emb::<Q>(&args.voice, cfg.model_ext().as_deref(), &dev)?;
         let load_ms = ms(t_load.elapsed());
 
         // Tokenize up front: the loop needs the tokens anyway, and the KV cache is sized from
@@ -347,8 +261,7 @@ impl Bench<'_> {
             .iter()
             .map(|(tokens, _)| voice_len + tokens.len() + max_frames_for(tokens.len()))
             .max()
-            .unwrap_or(voice_len)
-            + SEQ_BUDGET_SLACK;
+            .unwrap_or(voice_len);
         let t_voice = Instant::now();
         let mut base_state = model.init_flow_lm_state(1, seq_budget)?;
         model.prompt_audio(&mut base_state, &voice_emb)?;
@@ -370,26 +283,24 @@ impl Bench<'_> {
             }
             runs.push(r);
         }
-        if runs.is_empty() {
-            anyhow::bail!("--iters must be at least 1")
-        }
-
-        let audio_ms = runs[0].samples as f64 / model.sample_rate() as f64 * 1e3;
+        let first = &runs[0];
+        let audio_ms = |r: &Run| r.samples as f64 / model.sample_rate() as f64 * 1e3;
         let totals: Vec<f64> = runs.iter().map(|r| ms(r.total)).collect();
         let ttfas: Vec<f64> = runs.iter().map(|r| ms(r.ttfa)).collect();
         // Pooled across iterations: per-frame variation matters more than which run it came
         // from, and one run has too few frames for a stable tail.
         let frames: Vec<f64> = runs.iter().flat_map(|r| r.frames.iter().copied().map(ms)).collect();
         // Audio produced per unit of wall time, so higher is faster than realtime.
-        let rtfs: Vec<f64> = totals.iter().map(|t| audio_ms / t).collect();
+        let rtfs: Vec<f64> = runs.iter().map(|r| audio_ms(r) / ms(r.total)).collect();
 
         println!();
         println!(
-            "model {}  threads {}  input {} chars  audio {audio_ms:.0}ms  frames/iter {}",
+            "model {}  threads {}  input {} chars  audio {:.0}ms  frames/iter {}",
             args.model.display(),
             xn::get_num_threads(),
             args.input.len(),
-            runs[0].frames.len(),
+            audio_ms(first),
+            first.frames.len(),
         );
         println!("load {load_ms:.1}ms, voice conditioning {voice_ms:.1}ms (both excluded below)");
         println!();
@@ -397,17 +308,13 @@ impl Bench<'_> {
             "{:<22} {:>5}  {:>9} {:>9} {:>9} {:>9} {:>9}",
             "metric", "n", "min", "mean", "p50", "p95", "max"
         );
-        if let Some(s) = Stats::of(&totals) {
-            row("total generate", "ms", 2, &s);
-        }
-        if let Some(s) = Stats::of(&ttfas) {
-            row("time to first audio", "ms", 2, &s);
-        }
-        if let Some(s) = Stats::of(&frames) {
-            row("per-frame", "ms", 3, &s);
-        }
-        if let Some(s) = Stats::of(&rtfs) {
-            row("rtf (higher is better)", "x realtime", 2, &s);
+        for (label, unit, prec, xs) in [
+            ("total generate", "ms", 2, &totals),
+            ("time to first audio", "ms", 2, &ttfas),
+            ("per-frame", "ms", 3, &frames),
+            ("rtf (higher is better)", "x realtime", 2, &rtfs),
+        ] {
+            row(label, unit, prec, &Stats::of(xs));
         }
         Ok(())
     }

--- a/ptts/examples/create_voice.rs
+++ b/ptts/examples/create_voice.rs
@@ -1,11 +1,12 @@
 #[path = "audio_helpers.rs"]
 mod audio_helpers;
+#[path = "model_helpers.rs"]
+mod model_helpers;
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use ptts::tts_model::MimiEnc;
 use xn::Tensor;
-use xn::nn::VB;
 
 #[derive(Parser, Debug)]
 #[command(name = "create-voice")]
@@ -23,33 +24,6 @@ struct Args {
     /// Voice to use
     #[arg(long)]
     input: String,
-}
-
-fn remap_key(name: &str) -> Option<String> {
-    // Skip keys we don't need
-    if name.contains("flow.w_s_t")
-        || name.contains("quantizer.vq")
-        || name.contains("quantizer.logvar_proj")
-    {
-        return None;
-    }
-
-    let mut name = name.to_string();
-
-    // Order matters: more specific replacements first
-    name = name.replace(
-        "flow_lm.condition_provider.conditioners.speaker_wavs.output_proj.weight",
-        "flow_lm.speaker_proj_weight",
-    );
-    name = name.replace(
-        "flow_lm.condition_provider.conditioners.transcript_in_segment.",
-        "flow_lm.conditioner.",
-    );
-    name = name.replace("flow_lm.backbone.", "flow_lm.transformer.");
-    name = name.replace("flow_lm.flow.", "flow_lm.flow_net.");
-    name = name.replace("mimi.model.", "mimi.");
-
-    Some(name)
 }
 
 fn main() -> Result<()> {
@@ -109,14 +83,7 @@ fn run(args: Args) -> Result<()> {
     let pcm_tensor = Tensor::from_vec(pcm, (1, 1, ()), &dev)?.to::<f32>()?;
 
     tracing::info!(?model_path, "loading model");
-    let vb = if model_path.extension().and_then(|v| v.to_str()) == Some("gguf") {
-        let reader = std::fs::File::open(&model_path)?;
-        let reader = std::io::BufReader::new(reader);
-        VB::load_gguf_with_key_map(reader, dev, remap_key)?
-    } else {
-        VB::load_with_key_map(&[&model_path], dev, remap_key)?
-    };
-    let vb = vb.root();
+    let vb = model_helpers::load_weights::<xn::Unquantized<f32, xn::CpuDevice>>(&model_path, &dev)?;
     let mimi_enc: MimiEnc<xn::Unquantized<f32, xn::CpuDevice>> = MimiEnc::load(&vb, &cfg)?;
     tracing::info!("encoding audio to latent");
     let emb = mimi_enc.encode_audio(&pcm_tensor)?;

--- a/ptts/examples/model_helpers.rs
+++ b/ptts/examples/model_helpers.rs
@@ -1,0 +1,116 @@
+//! Weight loading shared by the `pocket_tts`, `bench` and `create_voice` examples.
+//!
+//! Each example includes this via `#[path = "model_helpers.rs"] mod model_helpers;`, the same
+//! way they share `audio_helpers.rs`, so not every example uses every item here.
+#![allow(dead_code)]
+
+use anyhow::{Context, Result};
+use xn::nn::{Path, VB};
+use xn::{BackendQ, Tensor};
+
+/// Maps upstream checkpoint names onto the names this crate's modules expect, dropping the
+/// tensors the runtime has no use for.
+pub fn remap_key(name: &str) -> Option<String> {
+    // Skip keys we don't need
+    if name.contains("flow.w_s_t")
+        || name.contains("quantizer.vq")
+        || name.contains("quantizer.logvar_proj")
+    {
+        return None;
+    }
+
+    let mut name = name.to_string();
+
+    // Order matters: more specific replacements first
+    name = name.replace(
+        "flow_lm.condition_provider.conditioners.speaker_wavs.output_proj.weight",
+        "flow_lm.speaker_proj_weight",
+    );
+    name = name.replace(
+        "flow_lm.condition_provider.conditioners.transcript_in_segment.",
+        "flow_lm.conditioner.",
+    );
+    name = name.replace("flow_lm.backbone.", "flow_lm.transformer.");
+    name = name.replace("flow_lm.flow.", "flow_lm.flow_net.");
+    name = name.replace("mimi.model.", "mimi.");
+
+    Some(name)
+}
+
+/// Loads GGUF or safetensors weights, picking the format from the extension.
+pub fn load_weights<Q: BackendQ>(path: &std::path::Path, dev: &Q::B) -> Result<Path<Q::B>> {
+    let vb = if path.extension().and_then(|v| v.to_str()) == Some("gguf") {
+        let reader = std::io::BufReader::new(std::fs::File::open(path)?);
+        VB::load_gguf_with_key_map(reader, dev.clone(), remap_key)?
+    } else {
+        VB::load_with_key_map(&[path], dev.clone(), remap_key)?
+    };
+    Ok(vb.root())
+}
+
+/// Tensors that `TTSModel::load` legitimately leaves untouched: the encoder side is only pulled
+/// in later by `MimiEnc::load`, and the quantizer is replaced by `dummy_quantizer`.
+pub fn is_unused_by_tts_model(name: &str) -> bool {
+    name == "flow_lm.condition_provider.conditioners.speaker_wavs.learnt_padding"
+        || name.starts_with("mimi.quantizer")
+        || name.starts_with("mimi.encoder")
+        || name.starts_with("speaker_mimi")
+        || name == "flow_lm.speaker_proj_weight"
+        || name == "mimi.downsample.conv.conv.weight"
+}
+
+/// Loads a precomputed voice embedding as `[1, T, dim]`, checking it was made for this model.
+pub fn load_voice_emb<Q: BackendQ>(
+    path: &std::path::Path,
+    model_ext: Option<&str>,
+    dev: &Q::B,
+) -> Result<Tensor<Q::T, Q::B>> {
+    let vb = VB::load(&[path], dev.clone())?;
+    let names = vb.tensor_names();
+    let key = names.first().context("no tensors found in voice embedding file")?;
+    let shape = vb.shape(key).context("voice tensor not found")?;
+    let dims = shape.dims().to_vec();
+    let emb: Tensor<f32, Q::B> = vb.tensor(key, shape)?;
+    // Voice files hold either [T, dim] or an already batched [1, T, dim].
+    let emb = if dims.len() == 2 { emb.reshape((1, dims[0], dims[1]))? } else { emb };
+    if let Some(model_ext) = model_ext {
+        let file_content = std::fs::read(path)?;
+        let (_, metadata) = safetensors::SafeTensors::read_metadata(&file_content)?;
+        if let Some(metadata) = metadata.metadata()
+            && let Some(voice_model_ext) = metadata.get("model_ext")
+            && voice_model_ext.as_str() != model_ext
+        {
+            anyhow::bail!(
+                "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
+            )
+        }
+    }
+    Ok(emb.to::<Q::T>()?)
+}
+
+/// Frames an utterance of `num_tokens` tokens is allowed to generate before it is cut off.
+pub fn max_frames_for(num_tokens: usize) -> usize {
+    ((num_tokens as f64 / 3.0 + 2.0) * 12.5).ceil() as usize
+}
+
+#[cfg(feature = "sp")]
+pub struct SpTokenizer(pub sentencepiece::SentencePieceProcessor);
+
+#[cfg(feature = "sp")]
+impl SpTokenizer {
+    pub fn open(path: &std::path::Path) -> Result<Self> {
+        let path = path.to_str().context("invalid tokenizer path")?;
+        Ok(Self(sentencepiece::SentencePieceProcessor::open(path)?))
+    }
+}
+
+#[cfg(feature = "sp")]
+impl ptts::Tokenizer for SpTokenizer {
+    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
+        Ok(self.0.encode(text).map_err(xn::Error::wrap)?.into_iter().map(|v| v.id).collect())
+    }
+
+    fn decode(&self, tokens: &[u32]) -> xn::Result<String> {
+        self.0.decode_piece_ids(tokens).map_err(xn::Error::wrap)
+    }
+}

--- a/ptts/examples/model_helpers.rs
+++ b/ptts/examples/model_helpers.rs
@@ -78,11 +78,13 @@ pub fn load_voice_emb<Q: BackendQ>(
         let (_, metadata) = safetensors::SafeTensors::read_metadata(&file_content)?;
         if let Some(metadata) = metadata.metadata()
             && let Some(voice_model_ext) = metadata.get("model_ext")
-            && voice_model_ext.as_str() != model_ext
         {
-            anyhow::bail!(
-                "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
-            )
+            tracing::info!(?voice_model_ext, "voice embedding model_ext from metadata");
+            if voice_model_ext.as_str() != model_ext {
+                anyhow::bail!(
+                    "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
+                )
+            }
         }
     }
     Ok(emb.to::<Q::T>()?)

--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -1,25 +1,15 @@
 #[path = "audio_helpers.rs"]
 mod audio_helpers;
+#[path = "model_helpers.rs"]
+mod model_helpers;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use model_helpers::{SpTokenizer, max_frames_for};
 use ptts::tts_model::{
     MimiEnc, TTSConfig, TTSModel, prepare_text_prompt, split_into_best_sentences,
 };
 use xn::Tensor;
-use xn::nn::VB;
-
-struct SpTokenizer(sentencepiece::SentencePieceProcessor);
-
-impl ptts::Tokenizer for SpTokenizer {
-    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
-        Ok(self.0.encode(text).map_err(xn::Error::wrap)?.into_iter().map(|v| v.id).collect())
-    }
-
-    fn decode(&self, tokens: &[u32]) -> xn::Result<String> {
-        self.0.decode_piece_ids(tokens).map_err(xn::Error::wrap)
-    }
-}
 
 #[derive(Parser, Debug)]
 #[command(name = "pocket-tts")]
@@ -111,33 +101,6 @@ fn download_files(voice: &str) -> Result<(std::path::PathBuf, std::path::PathBuf
         Voice::Audio(voice.to_string())
     };
     Ok((model_path, tokenizer_path, voice))
-}
-
-fn remap_key(name: &str) -> Option<String> {
-    // Skip keys we don't need
-    if name.contains("flow.w_s_t")
-        || name.contains("quantizer.vq")
-        || name.contains("quantizer.logvar_proj")
-    {
-        return None;
-    }
-
-    let mut name = name.to_string();
-
-    // Order matters: more specific replacements first
-    name = name.replace(
-        "flow_lm.condition_provider.conditioners.speaker_wavs.output_proj.weight",
-        "flow_lm.speaker_proj_weight",
-    );
-    name = name.replace(
-        "flow_lm.condition_provider.conditioners.transcript_in_segment.",
-        "flow_lm.conditioner.",
-    );
-    name = name.replace("flow_lm.backbone.", "flow_lm.transformer.");
-    name = name.replace("flow_lm.flow.", "flow_lm.flow_net.");
-    name = name.replace("mimi.model.", "mimi.");
-
-    Some(name)
 }
 
 fn init_tracing(chrome_tracing: bool) -> Option<tracing_chrome::FlushGuard> {
@@ -364,9 +327,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
         }
     };
 
-    let tokenizer_path = tokenizer_path.to_str().context("invalid tokenizer path")?;
-    let sp = sentencepiece::SentencePieceProcessor::open(tokenizer_path)?;
-    let tokenizer = SpTokenizer(sp);
+    let tokenizer = SpTokenizer::open(&tokenizer_path)?;
     let chunks = split_into_best_sentences(&tokenizer, &args.text, None)?;
 
     let mut rng = match args.rng_values {
@@ -384,22 +345,9 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
 
     let model_ext = cfg.model_ext();
     tracing::info!(?model_path, ?model_ext, "loading model");
-    let vb = if model_path.extension().and_then(|v| v.to_str()) == Some("gguf") {
-        let reader = std::fs::File::open(&model_path)?;
-        let reader = std::io::BufReader::new(reader);
-        VB::load_gguf_with_key_map(reader, dev.clone(), remap_key)?
-    } else {
-        VB::load_with_key_map(&[&model_path], dev.clone(), remap_key)?
-    };
-    let vb = vb.root();
+    let vb = model_helpers::load_weights::<Q>(&model_path, &dev)?;
     let model: TTSModel<Q> = TTSModel::load(&vb, Box::new(tokenizer), &cfg)?;
-    vb.check_all_used_with_ignore(|v| {
-        v == "flow_lm.condition_provider.conditioners.speaker_wavs.learnt_padding"
-            || v.starts_with("mimi.quantizer")
-            || v.starts_with("mimi.encoder")
-            || v == "flow_lm.speaker_proj_weight"
-            || v == "mimi.downsample.conv.conv.weight"
-    })?;
+    vb.check_all_used_with_ignore(model_helpers::is_unused_by_tts_model)?;
     tracing::info!("model loaded successfully!");
 
     let mut max_seq_budget = 0;
@@ -409,7 +357,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
         let tokens = model.flow_lm.conditioner.tokenize(&text)?;
         let num_tokens = tokens.len();
         tracing::info!(?text, ?num_tokens, "processing text");
-        let max_frames = ((num_tokens as f64 / 3.0 + 2.0) * 12.5).ceil() as usize;
+        let max_frames = max_frames_for(num_tokens);
         let seq_budget = num_tokens + 512 + max_frames;
         max_seq_budget = max_seq_budget.max(seq_budget);
         all_tokens.push((tokens, max_frames, frames_after_eos));
@@ -430,39 +378,15 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
     if let Some(voice) = voice {
         let (voice_emb, null_emb) = match voice {
             Voice::Safetensors(voice_path) => {
-                let voice_vb = VB::load(&[&voice_path], dev.clone())?;
-                let voice_names = voice_vb.tensor_names();
-                let voice_key =
-                    voice_names.first().context("no tensors found in voice embedding file")?;
-                let voice_shape = voice_vb.shape(voice_key).context("voice tensor not found")?;
-                let voice_dims = voice_shape.dims();
-
-                // Load as raw tensor and reshape to [1, T, dim]
-                let voice_emb: Tensor<f32, Q::B> =
-                    voice_vb.tensor(voice_key, voice_shape.clone())?;
-                let voice_emb = if voice_dims.len() == 2 {
-                    voice_emb.reshape((1, voice_dims[0], voice_dims[1]))?
-                } else {
-                    voice_emb
-                };
                 if cfg_state.is_some() {
                     anyhow::bail!("cfg is not supported with pre-computed voice embeddings");
                 }
-                if let Some(model_ext) = cfg.model_ext() {
-                    let file_content = std::fs::read(&voice_path)?;
-                    let (_, metadata) = safetensors::SafeTensors::read_metadata(&file_content)?;
-                    if let Some(metadata) = metadata.metadata()
-                        && let Some(voice_model_ext) = metadata.get("model_ext")
-                    {
-                        tracing::info!(?voice_model_ext, "voice embedding model_ext from metadata");
-                        if voice_model_ext.as_str() != model_ext {
-                            anyhow::bail!(
-                                "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
-                            );
-                        }
-                    }
-                }
-                (voice_emb.to::<Q::T>()?, None)
+                let voice_emb = model_helpers::load_voice_emb::<Q>(
+                    &voice_path,
+                    cfg.model_ext().as_deref(),
+                    &dev,
+                )?;
+                (voice_emb, None)
             }
             Voice::Audio(path) => {
                 tracing::info!("loading voice from audio file {}", path);


### PR DESCRIPTION
# Add a `bench` example

One new example, plus a shared `model_helpers` module that the three weight-loading
`ptts` examples now go through.

## Motivation
This PR adds a way to measure inference performance within this repository.

## Usage

```
cargo run --release --features sp,accelerate --example bench -- \
  --model model/model.q8.gguf --config model/config.json --quant q8 \
  --voice voices/freya.safetensors --threads 8 --iters 20
```

```
model model/model.q8.gguf  threads 8  input 47 chars  audio 4320ms  frames/iter 54
load 104.3ms, voice conditioning 71.1ms (both excluded below)

metric                     n        min      mean       p50       p95       max
total generate            20     543.60    550.77    549.31    555.73    563.87  ms
time to first audio       20      22.89     23.48     23.26     25.13     25.87  ms
per-frame               1080      9.024     9.942     9.902    10.571    15.944  ms
rtf (higher is better)    20       7.66      7.84      7.87      7.92      7.95  x realtime
```

## Shared helpers

This PR adds `ptts/examples/model_helpers.rs` and points all three entrypoints at it, following the
`#[path = "audio_helpers.rs"] mod` pattern the examples already used. It holds
`remap_key`, the GGUF/safetensors load branch, the unused-tensor ignore predicate,
precomputed-voice loading, the `max_frames` formula, and the `SpTokenizer` adapter
(behind `#[cfg(feature = "sp")]`, so `create_voice` still builds without `sp`).

Before this, `remap_key` was duplicated in three examples and `SpTokenizer`
in two; the load branch appeared three times and voice loading twice. Examples drop
from three copies of `remap_key` to one.

**This fixes a live `pocket_tts` bug.** The `check_all_used_with_ignore` lists had
drifted, and unifying them surfaced why: `speaker_mimi.*` weights are loaded by
`MimiEnc::load`, not `TTSModel::load`, and `pocket_tts` runs the check *before*
`MimiEnc::load` without ignoring that prefix. On a model with a separate speaker Mimi
— the case #10 just added — `pocket_tts` fails the check. It now shares bench's
predicate, which covers `speaker_mimi`.

## Testing

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p ptts --features sp --examples -- -D warnings` | clean |
| `cargo clippy -p ptts --examples -- -D warnings` (no `sp`) | clean |
| `cargo check -p ptts --features sp,metal --examples` | clean |
| `cargo check --workspace` | clean |
| `cargo test --lib --examples --features sp` | passes (0 tests exist) |
| q8 GGUF + precomputed voice | runs, output above |
| f32 safetensors, no `--quant` | runs |
| GGUF without `--quant` | clear error |
| `--iters 0` | rejected by clap at parse time |
| `pocket_tts` / `create_voice` after refactor | compile clean; not re-run end-to-end |
| cuda / vulkan | not compiled (no local toolchain) |
| metal | compiles; not run |
