### PR TITLE
fix: give the bench example's WithQ impl an Output type

### DIFF
--- a/ptts/examples/bench.rs
+++ b/ptts/examples/bench.rs
@@ -198,6 +198,8 @@ fn row(label: &str, unit: &str, prec: usize, st: &Stats) {
 struct Bench<'a>(&'a Args);
 
 impl xn::WithQ for Bench<'_> {
+    type Output = ();
+
     fn run<Q: BackendQ>(self, dev: Q::B) -> xn::Result<()> {
         self.bench::<Q>(dev).map_err(|e| xn::Error::msg(format!("{e:?}")))
     }


### PR DESCRIPTION
`WithQ` gained an associated `Output` in xn 0.2, so `cargo build --example bench --features sp` has not compiled since the 0.2.4 bump. CI never caught it because the example is gated behind `sp`, which `cargo check` and `cargo test` do not enable.