### PR TITLE
perf: fused single-query attention in the flow LM

### DIFF
--- a/ptts/src/flow_lm.rs
+++ b/ptts/src/flow_lm.rs
@@ -58,7 +58,10 @@ pub struct FlowLM<Q: BackendQ> {
     pub transformer: StreamingTransformer<Q>,
     pub emb_std: Tensor<Q::T, Q::B>,
     pub emb_mean: Tensor<Q::T, Q::B>,
-    bos_emb: Tensor<Q::T, Q::B>,
+    /// Host copy of `bos_emb`. `replace_nan_with_bos` runs on the host and needs
+    /// it every step; the tensor itself is never used on-device, and reading it
+    /// back each step costs a full device round trip on a gpu backend.
+    bos_emb: Vec<Q::T>,
     pub input_linear: Linear<Q::T, Q::B>,
     out_norm_weight: Tensor<Q::T, Q::B>,
     out_norm_bias: Tensor<Q::T, Q::B>,
@@ -120,7 +123,7 @@ impl<Q: BackendQ> FlowLM<Q> {
 
         let emb_std = vb.tensor("emb_std", (cfg.ldim,))?;
         let emb_mean = vb.tensor("emb_mean", (cfg.ldim,))?;
-        let bos_emb = vb.tensor("bos_emb", (cfg.ldim,))?;
+        let bos_emb = vb.tensor("bos_emb", (cfg.ldim,))?.to_vec()?;
         let input_linear = Linear::load(vb.pp("input_linear"), cfg.ldim, cfg.d_model)?;
         let out_norm_weight = vb.pp("out_norm").tensor("weight", (cfg.d_model,))?;
         let out_norm_bias = vb.pp("out_norm").tensor("bias", (cfg.d_model,))?;
@@ -244,7 +247,7 @@ impl<Q: BackendQ> FlowLM<Q> {
         let data = sequence.to_vec()?;
         // TODO(laurent): avoid the `to_vec` below. For this, we could introduce
         // something like torch.where.
-        let bos_data = self.bos_emb.to_vec()?;
+        let bos_data = &self.bos_emb;
         let mut out_data = data.clone();
         let ldim = self.ldim;
 

--- a/ptts/src/flow_lm.rs
+++ b/ptts/src/flow_lm.rs
@@ -58,9 +58,6 @@ pub struct FlowLM<Q: BackendQ> {
     pub transformer: StreamingTransformer<Q>,
     pub emb_std: Tensor<Q::T, Q::B>,
     pub emb_mean: Tensor<Q::T, Q::B>,
-    /// Host copy of `bos_emb`. `replace_nan_with_bos` runs on the host and needs
-    /// it every step; the tensor itself is never used on-device, and reading it
-    /// back each step costs a full device round trip on a gpu backend.
     bos_emb: Vec<Q::T>,
     pub input_linear: Linear<Q::T, Q::B>,
     out_norm_weight: Tensor<Q::T, Q::B>,

--- a/ptts/src/transformer.rs
+++ b/ptts/src/transformer.rs
@@ -1,7 +1,7 @@
 use crate::layer_scale::LayerScale;
 use crate::rope::RotaryEmbedding;
 use xn::nn::{LayerNorm, Linear, var_builder::Path};
-use xn::{Backend, BackendQ, Result, Tensor, WithDTypeF};
+use xn::{Backend, BackendQ, Result, Tensor, TensorView, WithDTypeF};
 
 /// State for StreamingMultiheadAttention.
 #[derive(Debug, Clone)]
@@ -24,16 +24,16 @@ impl<T: WithDTypeF, B: Backend> StreamingMHAState<T, B> {
         &mut self,
         k: &Tensor<T, B>,
         v: &Tensor<T, B>,
-    ) -> Result<(Tensor<T, B>, Tensor<T, B>)> {
+    ) -> Result<(TensorView<T, B>, TensorView<T, B>)> {
         let t = k.dim(1usize)?;
 
         self.k_cache.slice_set(k, 1usize, self.current_end)?;
         self.v_cache.slice_set(v, 1usize, self.current_end)?;
 
-        let new_end = self.current_end + t;
-        let keys = self.k_cache.narrow(1, 0..new_end)?.contiguous()?;
-        let values = self.v_cache.narrow(1, 0..new_end)?.contiguous()?;
-        self.current_end = new_end;
+        self.current_end += t;
+        let new_end = self.current_end;
+        let keys = self.k_cache.narrow(1, 0..new_end)?;
+        let values = self.v_cache.narrow(1, 0..new_end)?;
         Ok((keys, values))
     }
 
@@ -119,23 +119,31 @@ impl<Q: BackendQ> StreamingMultiheadAttention<Q> {
         let (q, k) = rope.forward(&q, &k)?;
         let (k, v) = state.complete_kv(&k, &v)?;
 
-        // Transpose to [b, h, t, d] for attention
-        let q = q.transpose(1, 2)?;
-        let k = k.transpose(1, 2)?;
-        let v = v.transpose(1, 2)?;
+        let inv_sqrt_d = 1.0 / (d as f32).sqrt();
+        // Single-query decode is the steady-state case; composing it costs a batch of `h` tiny
+        // matmuls per projection plus a separate softmax pass. The fused kernel wants exactly
+        // the [b, t, h, d] layout we already have, and falls back internally if the operand
+        // layout is not one it handles.
+        let x = if t == 1 {
+            q.sdpa_decode(&k, &v, mask, inv_sqrt_d)?
+        } else {
+            // Transpose to [b, h, t, d] for attention
+            let q = q.transpose(1, 2)?;
+            let k = k.transpose(1, 2)?;
+            let v = v.transpose(1, 2)?;
 
-        // Scaled dot-product attention
-        let scale = Q::T::from_f32(1.0 / (d as f32).sqrt());
-        let attn = q.matmul_t(&k)?.scale(scale)?;
-        let attn = match mask {
-            Some(m) => attn.broadcast_add(m)?,
-            None => attn,
+            let scale = Q::T::from_f32(inv_sqrt_d);
+            let attn = q.matmul_t(&k)?.scale(scale)?;
+            let attn = match mask {
+                Some(m) => attn.broadcast_add(m)?,
+                None => attn,
+            };
+            let attn = attn.softmax()?;
+            let x = attn.matmul(&v)?;
+
+            // Back to [b, t, h*d]
+            x.transpose(1, 2)?.reshape((b, t, self.embed_dim))?.contiguous()?
         };
-        let attn = attn.softmax()?;
-        let x = attn.matmul(&v)?;
-
-        // Back to [b, t, h*d]
-        let x = x.transpose(1, 2)?.reshape((b, t, self.embed_dim))?.contiguous()?;
         self.out_proj.forward(&x)
     }
 }

--- a/ptts/src/transformer.rs
+++ b/ptts/src/transformer.rs
@@ -120,10 +120,7 @@ impl<Q: BackendQ> StreamingMultiheadAttention<Q> {
         let (k, v) = state.complete_kv(&k, &v)?;
 
         let inv_sqrt_d = 1.0 / (d as f32).sqrt();
-        // Single-query decode is the steady-state case; composing it costs a batch of `h` tiny
-        // matmuls per projection plus a separate softmax pass. The fused kernel wants exactly
-        // the [b, t, h, d] layout we already have, and falls back internally if the operand
-        // layout is not one it handles.
+
         let x = if t == 1 {
             q.sdpa_decode(&k, &v, mask, inv_sqrt_d)?
         } else {
@@ -132,6 +129,7 @@ impl<Q: BackendQ> StreamingMultiheadAttention<Q> {
             let k = k.transpose(1, 2)?;
             let v = v.transpose(1, 2)?;
 
+            // Scaled dot-product attention
             let scale = Q::T::from_f32(inv_sqrt_d);
             let attn = q.matmul_t(&k)?.scale(scale)?;
             let attn = match mask {


### PR DESCRIPTION
Three improvements on the decode path at `t == 1`.

`complete_kv` returned `contiguous()` copies of the whole key and value cache every step, for every layer. The narrows are what attention wants, so they are returned as views and the two copies per layer disappear.

Single-query attention was composed out of a batch of `h` tiny matmuls per projection plus a separate softmax pass. `sdpa_decode` (xn #62) fuses that, and wants exactly the [b, t, h, d] layout already in hand. It falls back internally if the operand layout is not one it handles, so the composed path stays for prefill.

`bos_emb` was read back from the device on every step by `replace_nan_with_bos`, which runs on the host. It never gets used on-device, so it is kept as a host copy and the per-step round trip goes away.

---

## Benchmarks

Paired A/B against `main`: each configuration is timed immediately after a fresh baseline
sample, so the figure is a ratio and machine drift cancels. Median of interleaved rounds,
per-frame p50, q8 GGUF.

| machine | threads | speedup |
|---|---|---|
| M5 | 4 | 1.066x |
| M5 | 8 | **1.100x** |
| Pi 5 | 2 | 1.049x |
| Pi 5 | 4 | 1.070x |