### PR TITLE
feat: replace sentencepiece with hf tokenizer

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,8 +8,8 @@ rustflags = ["-C", "target-feature=+simd128,+relaxed-simd", "--cfg", "getrandom_
 runner = "wasmtime"
 rustflags = ["-C", "target-feature=+simd128,+relaxed-simd"]
 
-# `cc-rs` build scripts (e.g. for `onig_sys`) need a sysroot when targeting
-# wasi. These vars are target-prefixed so they're harmless on host builds.
+# `cc-rs` build scripts need a sysroot when targeting wasi. These vars are
+# target-prefixed so they're harmless on host builds.
 [env]
 WASI_SYSROOT = "/usr/share/wasi-sysroot"
 CC_wasm32_wasip1 = "clang"

--- a/.github/workflows/maturin-pub.yml
+++ b/.github/workflows/maturin-pub.yml
@@ -88,12 +88,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path ptts-pyo3/Cargo.toml
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        env:
-          # `esaxx-rs` (via `tokenizers`, built with cc) links the static CRT
-          # while `sentencepiece-sys` (built with cmake) links the dynamic CRT,
-          # which fails with LNK2038 RuntimeLibrary mismatch. Force the static
-          # CRT everywhere so Rust, cc and cmake all agree on /MT.
-          RUSTFLAGS: "-C target-feature=+crt-static"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -16,13 +16,6 @@ jobs:
         shell: bash
         # Remove the target-arch=native as it breaks some dependencies.
         run: rm -f .cargo/config.toml
-      - name: Use static CRT on Windows
-        if: runner.os == 'Windows'
-        shell: bash
-        # esaxx-rs (built with cc, /MT) and sentencepiece-sys (built with cmake,
-        # /MD) otherwise disagree on the MSVC runtime and fail to link with
-        # LNK2038. Force the static CRT everywhere so they all agree on /MT.
-        run: echo "RUSTFLAGS=-C target-feature=+crt-static" >> "$GITHUB_ENV"
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -46,13 +39,6 @@ jobs:
         shell: bash
         # Remove the target-arch=native as it breaks some dependencies.
         run: rm -f .cargo/config.toml
-      - name: Use static CRT on Windows
-        if: runner.os == 'Windows'
-        shell: bash
-        # esaxx-rs (built with cc, /MT) and sentencepiece-sys (built with cmake,
-        # /MD) otherwise disagree on the MSVC runtime and fail to link with
-        # LNK2038. Force the static CRT everywhere so they all agree on /MT.
-        run: echo "RUSTFLAGS=-C target-feature=+crt-static" >> "$GITHUB_ENV"
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,8 @@ cargo run --release --example pocket_tts --features hf -- "hello world" -o out.w
   --tokenizer path/to/tokenizer.json
 ```
 
-It downloads weights from the `kyutai/pocket-tts` HuggingFace repo on first run. That repo ships
-only a SentencePiece `tokenizer.model`, so convert it once (`uv run scripts/convert-tokenizer.py
-<the cached tokenizer.model>`) and pass the result with `--tokenizer`; the flag can be dropped
-once a `tokenizer.json` is hosted alongside the weights. Built-in voice IDs: `alba`, `marius`, `javert`, `jean`, `fantine`, `cosette`, `eponine`, `azelma`. `--voice` also accepts a path to a 10s audio file or a precomputed voice safetensors.
+It downloads weights from the `kyutai/pocket-tts` HuggingFace repo on first run, along with that
+repo's `tokenizer.json` once it hosts one — until then `--tokenizer` supplies it. Built-in voice IDs: `alba`, `marius`, `javert`, `jean`, `fantine`, `cosette`, `eponine`, `azelma`. `--voice` also accepts a path to a 10s audio file or a precomputed voice safetensors.
 
 Benchmark a local model:
 
@@ -83,7 +81,7 @@ The library implements Pocket TTS: text → tokens → flow-matching language mo
 - `pocket_tts` and `bench` examples, `ptts-pyo3` and `ptts-ws-server`: `ptts::tok::Tok` (the `hf` feature), a Hugging Face `tokenizers` wrapper.
 - `ptts-wasm`: the same `ptts::tok::Tok`, built from the `tokenizer.json` the demo fetches and handed to `Model::new`; the browser passes text, not token ids.
 
-There is no SentencePiece dependency: every Rust frontend loads a `tokenizer.json` and nothing else. The published checkpoints ship a SentencePiece `tokenizer.model` instead, so it has to be converted once with `scripts/convert-tokenizer.py`, which emits an equivalent `tokenizer.json` (identical ids, verified against `sentencepiece` as it converts). No tokenizer is bundled or defaulted to — every checkpoint has its own vocabulary, and loading the wrong one yields plausible audio from the wrong ids — so `Tok::open` refuses a `.model` path, and a missing `tokenizer.json` next to one, with a pointer at the script. `pocket_tts --tokenizer <path>` and `bench --tokenizer <path>` point the examples at a converted file; `ptts-pyo3` and `ptts-ws-server` expect `tokenizer.json` in the HF repo or beside the config.
+Every frontend loads a `tokenizer.json` and nothing else, and none is bundled or defaulted to: each checkpoint has its own vocabulary, and loading the wrong one yields plausible audio from the wrong ids, so `Tok::open` refuses to guess. `pocket_tts --tokenizer <path>` and `bench --tokenizer <path>` override where the examples look; otherwise they, `ptts-pyo3` and `ptts-ws-server` all expect `tokenizer.json` in the HF repo or beside the config. A checkpoint that carries only a `tokenizer.model` needs converting once with `scripts/convert-tokenizer.py`, which writes the equivalent json.
 
 Top-level orchestrator is `tts_model::TTSModel<Q>`, generic over a backend-quantization parameter `Q: BackendQ` from `xn`. It owns:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ The library implements Pocket TTS: text → tokens → flow-matching language mo
 `ptts/src/lib.rs` exposes a single `Tokenizer` trait (`encode` / `decode`) so each binding plugs in its own implementation:
 
 - `pocket_tts` example, `ptts-pyo3` and `ptts-ws-server`: `ptts::tok::Tok` (the `hf` feature), a Hugging Face `tokenizers` wrapper.
-- `ptts-wasm`: `PresetTokenizer` — JS tokenizes in the browser and pushes IDs into the Rust state before each step.
+- `ptts-wasm`: the same `ptts::tok::Tok`, built from the `tokenizer.json` the demo fetches and handed to `Model::new`; the browser passes text, not token ids.
 
 There is no SentencePiece dependency: every Rust frontend loads a `tokenizer.json` and nothing else. The published checkpoints ship a SentencePiece `tokenizer.model` instead, so it has to be converted once with `scripts/convert-tokenizer.py`, which emits an equivalent `tokenizer.json` (identical ids, verified against `sentencepiece` as it converts). No tokenizer is bundled or defaulted to — every checkpoint has its own vocabulary, and loading the wrong one yields plausible audio from the wrong ids — so `Tok::open` refuses a `.model` path, and a missing `tokenizer.json` next to one, with a pointer at the script. `pocket_tts --tokenizer <path>` points the example at a converted file; `ptts-pyo3` and `ptts-ws-server` expect `tokenizer.json` in the HF repo or beside the config.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Cargo workspace (resolver "3", edition 2024) with three members:
 
-- `ptts/` — core TTS library. Pure Rust, depends on the `xn` tensor/nn crate. Examples live under `ptts/examples/`: `pocket_tts` (end-to-end CLI) and `bench` (benchmark harness) both require the `sp` feature for SentencePiece; `quantize` (safetensors → GGUF converter that selectively quantizes `flow_lm.transformer.layers.*` weights) and `create_voice` (voice embeddings from audio samples) do not. `audio_helpers.rs` and `model_helpers.rs` are not examples — they are shared modules each example pulls in with `#[path = "..."] mod`, so `autoexamples = false` and every example is listed explicitly in `Cargo.toml`.
+- `ptts/` — core TTS library. Pure Rust, depends on the `xn` tensor/nn crate. Examples live under `ptts/examples/`: `pocket_tts` (end-to-end CLI) and `bench` (benchmark harness) both require the `hf` feature for the tokenizer; `quantize` (safetensors → GGUF converter that selectively quantizes `flow_lm.transformer.layers.*` weights) and `create_voice` (voice embeddings from audio samples) do not. `audio_helpers.rs` and `model_helpers.rs` are not examples — they are shared modules each example pulls in with `#[path = "..."] mod`, so `autoexamples = false` and every example is listed explicitly in `Cargo.toml`.
 - `ptts-pyo3/` — PyO3 bindings exposing `TTSModel` to Python. Built with maturin; the cdylib is named `ptts`. Has its own `pyproject.toml` and `uv.lock`.
 - `ptts-wasm/` — browser build via `wasm-bindgen` / `wasm-pack`. Ships a demo in `ptts-wasm/www/` (`index.html` + `worker.js`).
 
@@ -27,16 +27,20 @@ CI deletes `.cargo/config.toml` before building because it pins `target-cpu=nati
 
 Cargo features that gate optional functionality:
 
-- `ptts`: `sp` (SentencePiece tokenizer, required by the `pocket_tts` and `bench` examples), `cuda`, `accelerate`.
+- `ptts`: `hf` (Hugging Face `tokenizers`, i.e. `ptts::tok`, required by the `pocket_tts` and `bench` examples), `cuda`, `accelerate`.
 - `ptts-pyo3`: `cuda`, `accelerate` (each forwards to both `xn/*` and `ptts/*`).
 
 Run the CLI example:
 
 ```
-cargo run --release --example pocket_tts --features sp -- "hello world" -o out.wav
+cargo run --release --example pocket_tts --features hf -- "hello world" -o out.wav \
+  --tokenizer path/to/tokenizer.json
 ```
 
-It downloads weights from the `kyutai/pocket-tts` HuggingFace repo on first run. Built-in voice IDs: `alba`, `marius`, `javert`, `jean`, `fantine`, `cosette`, `eponine`, `azelma`. `--voice` also accepts a path to a 10s audio file or a precomputed voice safetensors.
+It downloads weights from the `kyutai/pocket-tts` HuggingFace repo on first run. That repo ships
+only a SentencePiece `tokenizer.model`, so convert it once (`uv run scripts/convert-tokenizer.py
+<the cached tokenizer.model>`) and pass the result with `--tokenizer`; the flag can be dropped
+once a `tokenizer.json` is hosted alongside the weights. Built-in voice IDs: `alba`, `marius`, `javert`, `jean`, `fantine`, `cosette`, `eponine`, `azelma`. `--voice` also accepts a path to a 10s audio file or a precomputed voice safetensors.
 
 Benchmark a local model:
 
@@ -76,9 +80,10 @@ The library implements Pocket TTS: text → tokens → flow-matching language mo
 
 `ptts/src/lib.rs` exposes a single `Tokenizer` trait (`encode` / `decode`) so each binding plugs in its own implementation:
 
-- `pocket_tts` example: `SpTokenizer` wrapping `sentencepiece::SentencePieceProcessor`.
-- `ptts-pyo3`: tokenizer is built from `tokenizer.model` shipped in the HF repo.
+- `pocket_tts` example, `ptts-pyo3` and `ptts-ws-server`: `ptts::tok::Tok` (the `hf` feature), a Hugging Face `tokenizers` wrapper.
 - `ptts-wasm`: `PresetTokenizer` — JS tokenizes in the browser and pushes IDs into the Rust state before each step.
+
+There is no SentencePiece dependency: every Rust frontend loads a `tokenizer.json` and nothing else. The published checkpoints ship a SentencePiece `tokenizer.model` instead, so it has to be converted once with `scripts/convert-tokenizer.py`, which emits an equivalent `tokenizer.json` (identical ids, verified against `sentencepiece` as it converts). No tokenizer is bundled or defaulted to — every checkpoint has its own vocabulary, and loading the wrong one yields plausible audio from the wrong ids — so `Tok::open` refuses a `.model` path, and a missing `tokenizer.json` next to one, with a pointer at the script. `pocket_tts --tokenizer <path>` points the example at a converted file; `ptts-pyo3` and `ptts-ws-server` expect `tokenizer.json` in the HF repo or beside the config.
 
 Top-level orchestrator is `tts_model::TTSModel<Q>`, generic over a backend-quantization parameter `Q: BackendQ` from `xn`. It owns:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ once a `tokenizer.json` is hosted alongside the weights. Built-in voice IDs: `al
 Benchmark a local model:
 
 ```
-cargo run --release --features sp,accelerate --example bench -- \
+cargo run --release --features hf,accelerate --example bench -- \
   --model model/model.q8.gguf --config model/config.json --quant q8 \
   --voice voices/freya.safetensors --threads 8 --iters 20
 ```
@@ -80,10 +80,10 @@ The library implements Pocket TTS: text → tokens → flow-matching language mo
 
 `ptts/src/lib.rs` exposes a single `Tokenizer` trait (`encode` / `decode`) so each binding plugs in its own implementation:
 
-- `pocket_tts` example, `ptts-pyo3` and `ptts-ws-server`: `ptts::tok::Tok` (the `hf` feature), a Hugging Face `tokenizers` wrapper.
+- `pocket_tts` and `bench` examples, `ptts-pyo3` and `ptts-ws-server`: `ptts::tok::Tok` (the `hf` feature), a Hugging Face `tokenizers` wrapper.
 - `ptts-wasm`: the same `ptts::tok::Tok`, built from the `tokenizer.json` the demo fetches and handed to `Model::new`; the browser passes text, not token ids.
 
-There is no SentencePiece dependency: every Rust frontend loads a `tokenizer.json` and nothing else. The published checkpoints ship a SentencePiece `tokenizer.model` instead, so it has to be converted once with `scripts/convert-tokenizer.py`, which emits an equivalent `tokenizer.json` (identical ids, verified against `sentencepiece` as it converts). No tokenizer is bundled or defaulted to — every checkpoint has its own vocabulary, and loading the wrong one yields plausible audio from the wrong ids — so `Tok::open` refuses a `.model` path, and a missing `tokenizer.json` next to one, with a pointer at the script. `pocket_tts --tokenizer <path>` points the example at a converted file; `ptts-pyo3` and `ptts-ws-server` expect `tokenizer.json` in the HF repo or beside the config.
+There is no SentencePiece dependency: every Rust frontend loads a `tokenizer.json` and nothing else. The published checkpoints ship a SentencePiece `tokenizer.model` instead, so it has to be converted once with `scripts/convert-tokenizer.py`, which emits an equivalent `tokenizer.json` (identical ids, verified against `sentencepiece` as it converts). No tokenizer is bundled or defaulted to — every checkpoint has its own vocabulary, and loading the wrong one yields plausible audio from the wrong ids — so `Tok::open` refuses a `.model` path, and a missing `tokenizer.json` next to one, with a pointer at the script. `pocket_tts --tokenizer <path>` and `bench --tokenizer <path>` point the examples at a converted file; `ptts-pyo3` and `ptts-ws-server` expect `tokenizer.json` in the HF repo or beside the config.
 
 Top-level orchestrator is `tts_model::TTSModel<Q>`, generic over a backend-quantization parameter `Q: BackendQ` from `xn`. It owns:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,15 +789,23 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1907,17 +1915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,28 +1994,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "onig"
-version = "6.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "option-ext"
@@ -2197,29 +2172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ptts"
 version = "0.2.3"
 dependencies = [
@@ -2233,10 +2185,10 @@ dependencies = [
  "rand_distr",
  "rubato",
  "safetensors",
- "sentencepiece",
  "serde",
  "serde_json",
  "symphonia",
+ "tokenizers",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
@@ -2253,9 +2205,7 @@ dependencies = [
  "pyo3",
  "rand",
  "rand_distr",
- "sentencepiece",
  "serde_json",
- "tokenizers",
  "xn",
 ]
 
@@ -2290,10 +2240,8 @@ dependencies = [
  "rand",
  "rand_distr",
  "rubato",
- "sentencepiece",
  "serde",
  "serde_json",
- "tokenizers",
  "tokio",
  "tower-http",
  "tracing",
@@ -2701,32 +2649,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "sentencepiece"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa1506c7718f6b70bcac5475e563176dd51bb669dae38181abbf3070517453"
-dependencies = [
- "libc",
- "num-derive",
- "num-traits",
- "prost",
- "prost-derive",
- "sentencepiece-sys",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sentencepiece-sys"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f9b54dc005df8ec1c3f9e2347cea6b6657ec5460977a982e7a4e09ef49411"
-dependencies = [
- "cc",
- "cmake",
- "pkg-config",
-]
 
 [[package]]
 name = "seq-macro"
@@ -3266,13 +3188,12 @@ dependencies = [
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
+ "fancy-regex",
  "getrandom 0.3.4",
- "indicatif",
  "itertools",
  "log",
  "macro_rules_attribute",
  "monostate",
- "onig",
  "paste",
  "rand",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,7 +2173,7 @@ checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "ptts"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "ptts-pyo3"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "hf-hub",
  "numpy",
@@ -2211,7 +2211,7 @@ dependencies = [
 
 [[package]]
 name = "ptts-wasm"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "ptts-ws-server"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.3.0"
 description = "Pocket TTS inference and serving using xn"
 repository = "https://github.com/LaurentMazare/xn-ptts"
 keywords = ["pytorch", "deep-learning", "machine-learning"]
@@ -16,7 +16,7 @@ categories = ["science"]
 license = "MIT/Apache-2.0"
 
 [workspace.dependencies]
-ptts = { path = "ptts", version = "0.2.3" }
+ptts = { path = "ptts", version = "0.3.0" }
 
 anyhow = "1"
 axum = { version = "0.8", default-features = false, features = ["ws", "tokio", "http1", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,10 @@ rand = { version = "0.9.0", default-features = false }
 rand_distr = "0.5.0"
 rubato = "0.15.0"
 safetensors = "0.7.0"
-sentencepiece = "0.13.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 symphonia = { version = "0.5.3", features = ["all"] }
-tokenizers = "0.23.1"
+tokenizers = { version = "0.23.1", default-features = false, features = ["fancy-regex"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tower-http = { version = "0.6", features = ["trace"] }
 tracing = "0.1.44"

--- a/ptts-pyo3/Cargo.toml
+++ b/ptts-pyo3/Cargo.toml
@@ -14,15 +14,13 @@ crate-type = ["cdylib"]
 
 [dependencies]
 xn = { workspace = true }
-ptts = { workspace = true }
+ptts = { workspace = true, features = ["hf"] }
 hf-hub = { workspace = true }
 numpy = "0.28"
 pyo3 = { version = "0.28", features = ["extension-module"] }
 rand = { workspace = true, features = ["std_rng"] }
 rand_distr = { workspace = true }
-sentencepiece = { workspace = true }
 serde_json = { workspace = true }
-tokenizers = { workspace = true }
 
 [features]
 default = []

--- a/ptts-pyo3/src/lib.rs
+++ b/ptts-pyo3/src/lib.rs
@@ -1,4 +1,5 @@
 use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArrayDyn, PyUntypedArrayMethods};
+use ptts::tok::Tok;
 use ptts::tts_model::{MimiEnc, TTSConfig, TTSModel, TTSState};
 use pyo3::prelude::*;
 use std::sync::Arc;
@@ -845,43 +846,6 @@ impl ModelState {
     }
 }
 
-pub enum Tok {
-    Sp(std::sync::Arc<sentencepiece::SentencePieceProcessor>),
-    Hf(Box<tokenizers::Tokenizer>),
-}
-
-impl From<sentencepiece::SentencePieceProcessor> for Tok {
-    fn from(sp: sentencepiece::SentencePieceProcessor) -> Self {
-        Tok::Sp(std::sync::Arc::new(sp))
-    }
-}
-
-impl From<tokenizers::Tokenizer> for Tok {
-    fn from(tok: tokenizers::Tokenizer) -> Self {
-        Tok::Hf(Box::new(tok))
-    }
-}
-
-impl ptts::Tokenizer for Tok {
-    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
-        let tokens = match self {
-            Tok::Sp(sp) => {
-                sp.encode(text).map_err(xn::Error::wrap)?.into_iter().map(|v| v.id).collect()
-            }
-            Tok::Hf(tok) => tok.encode(text, false).map_err(xn::Error::wrap)?.get_ids().to_vec(),
-        };
-        Ok(tokens)
-    }
-
-    fn decode(&self, ids: &[u32]) -> xn::Result<String> {
-        let decoded = match self {
-            Tok::Sp(sp) => sp.decode_piece_ids(ids).map_err(xn::Error::wrap)?,
-            Tok::Hf(tok) => tok.decode(ids, true).map_err(xn::Error::wrap)?,
-        };
-        Ok(decoded)
-    }
-}
-
 fn remap_key(name: &str) -> Option<String> {
     if name.contains("flow.w_s_t")
         || name.contains("quantizer.vq")
@@ -944,7 +908,7 @@ fn load_model_<Q: BackendQ>(
             } else {
                 parent.join("model.q8.gguf")
             };
-            let tokenizer_path = parent.join("tokenizer.model");
+            let tokenizer_path = parent.join("tokenizer.json");
             let config_str = std::fs::read_to_string(&config_path)
                 .map_err(|e| xn::Error::msg(e).with_path(&config_path))?;
             let cfg: TTSConfig = serde_json::from_str(&config_str)
@@ -967,7 +931,7 @@ fn load_model_<Q: BackendQ>(
             cfg.temp = temperature;
 
             let model_path = repo.get("model.q8.gguf").map_err(xn::Error::msg)?;
-            let tokenizer_path = repo.get("tokenizer.model").map_err(xn::Error::msg)?;
+            let tokenizer_path = repo.get("tokenizer.json").map_err(xn::Error::msg)?;
 
             (model_path, tokenizer_path, cfg, std::collections::HashMap::new())
         }
@@ -979,7 +943,7 @@ fn load_model_<Q: BackendQ>(
 
             let model_path =
                 repo.get(&model_file).map_err(|e| xn::Error::msg(e).with_path(&model_file))?;
-            let tokenizer_path = repo.get("tokenizer.model").map_err(xn::Error::msg)?;
+            let tokenizer_path = repo.get("tokenizer.json").map_err(xn::Error::msg)?;
 
             let mut voices = std::collections::HashMap::new();
             for &voice in POCKET_TTS_VOICES {
@@ -997,16 +961,7 @@ fn load_model_<Q: BackendQ>(
         }
     };
 
-    let tokenizer_path = tokenizer_path.to_str().context("invalid tokenizer path")?;
-    let tokenizer = if tokenizer_path.ends_with(".model") {
-        let sp = sentencepiece::SentencePieceProcessor::open(tokenizer_path)
-            .map_err(|e| xn::Error::msg(e).with_path(tokenizer_path))?;
-        Tok::Sp(sp.into())
-    } else {
-        let tok = tokenizers::Tokenizer::from_file(tokenizer_path)
-            .map_err(|e| xn::Error::msg(e).with_path(tokenizer_path))?;
-        Tok::Hf(Box::new(tok))
-    };
+    let tokenizer = Tok::open(&tokenizer_path)?;
 
     // GGUF checkpoints carry weights already quantized; safetensors are
     // (re)quantized into `Q` on load.

--- a/ptts-wasm/Cargo.toml
+++ b/ptts-wasm/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-ptts = { workspace = true }
+ptts = { workspace = true, features = ["hf"] }
 xn = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }

--- a/ptts-wasm/README.md
+++ b/ptts-wasm/README.md
@@ -20,7 +20,7 @@ From the `ptts-wasm/` directory:
 make build
 ```
 
-This runs `wasm-pack build` and copies `index.html` into `pkg/`.
+This runs `wasm-pack build` and copies `www/` into `pkg/`.
 
 ## Run
 

--- a/ptts-wasm/src/lib.rs
+++ b/ptts-wasm/src/lib.rs
@@ -1,4 +1,3 @@
-use std::sync::Mutex;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -13,49 +12,12 @@ macro_rules! console_log {
 
 use ptts::flow_lm::{self, FlowLMState};
 use ptts::mimi::MimiDecoderState;
+use ptts::tok::Tok;
 use ptts::transformer::{LayerAttentionState, StreamingMHAState, StreamingTransformerState};
 use ptts::tts_model::{TTSConfig, TTSModel, TTSState, prepare_text_prompt};
 use xn::nn::VB;
 use xn::quantized::Q80F32;
 use xn::{BackendQ, CPU, CpuDevice, Tensor, TypedTensor, Unquantized};
-
-/// Tokenizer that returns pre-set token IDs (set from JS before each generation).
-struct PresetTokenizer {
-    tokens: Mutex<Vec<u32>>,
-}
-
-impl PresetTokenizer {
-    fn new() -> Self {
-        Self { tokens: Mutex::new(Vec::new()) }
-    }
-
-    fn set_tokens(&self, tokens: Vec<u32>) {
-        *self.tokens.lock().unwrap() = tokens;
-    }
-}
-
-impl ptts::Tokenizer for PresetTokenizer {
-    fn encode(&self, _text: &str) -> xn::Result<Vec<u32>> {
-        Ok(self.tokens.lock().unwrap().clone())
-    }
-
-    fn decode(&self, _tokens: &[u32]) -> xn::Result<String> {
-        Ok(String::new())
-    }
-}
-
-/// Wrapper to allow sharing a PresetTokenizer via Arc while implementing the Tokenizer trait.
-struct SharedTokenizer(std::sync::Arc<PresetTokenizer>);
-
-impl ptts::Tokenizer for SharedTokenizer {
-    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
-        self.0.encode(text)
-    }
-
-    fn decode(&self, tokens: &[u32]) -> xn::Result<String> {
-        self.0.decode(tokens)
-    }
-}
 
 struct WasmRng {
     inner: Box<rand::rngs::StdRng>,
@@ -199,14 +161,13 @@ struct GenState {
 #[wasm_bindgen]
 pub struct Model {
     inner: ModelInner,
-    tokenizer: std::sync::Arc<PresetTokenizer>,
     cfg: TTSConfig,
     gen_state: Option<GenState>,
     voice_states: Vec<RawState>,
 }
 
 impl Model {
-    pub fn new_(model_weights: &[u8], quant: &str) -> xn::Result<Model> {
+    pub fn new_(model_weights: &[u8], tokenizer_json: &[u8], quant: &str) -> xn::Result<Model> {
         let quant = Quant::parse(quant)?;
         console_log!("[new] loading model with quant={quant:?}");
         let cfg = TTSConfig::v202601(0.7);
@@ -221,9 +182,8 @@ impl Model {
             VB::from_bytes_with_key_map(vec![model_weights.to_vec()], CPU, remap_key)?
         };
         let root = vb.root();
-        let tokenizer = std::sync::Arc::new(PresetTokenizer::new());
         let tokenizer_box: Box<dyn ptts::Tokenizer + Send + Sync> =
-            Box::new(SharedTokenizer(std::sync::Arc::clone(&tokenizer)));
+            Box::new(Tok::from_bytes(tokenizer_json)?);
 
         let inner = match quant {
             Quant::F32 => ModelInner::F32(TTSModel::<Unquantized<f32, CpuDevice>>::load(
@@ -234,7 +194,7 @@ impl Model {
             Quant::Q8 => ModelInner::Q8(TTSModel::<Q80F32>::load(&root, tokenizer_box, &cfg)?),
         };
 
-        Ok(Model { inner, tokenizer, cfg, gen_state: None, voice_states: Vec::new() })
+        Ok(Model { inner, cfg, gen_state: None, voice_states: Vec::new() })
     }
 
     /// Load a pre-computed KV cache state from a safetensors buffer.
@@ -284,10 +244,14 @@ impl Model {
     pub fn start_generation_(
         &mut self,
         voice_index: usize,
-        token_ids: &[u32],
-        frames_after_eos: usize,
+        text: &str,
         temperature: f32,
-    ) -> xn::Result<()> {
+    ) -> xn::Result<usize> {
+        let (text, frames_after_eos) = prepare_text_prompt(text);
+        let token_ids = match &self.inner {
+            ModelInner::F32(m) => m.flow_lm.conditioner.tokenize(&text)?,
+            ModelInner::Q8(m) => m.flow_lm.conditioner.tokenize(&text)?,
+        };
         console_log!(
             "[start_generation] voice_index={} num_tokens={} frames_after_eos={} temperature={}",
             voice_index,
@@ -295,7 +259,6 @@ impl Model {
             frames_after_eos,
             temperature
         );
-        self.tokenizer.set_tokens(token_ids.to_vec());
 
         let num_tokens = token_ids.len();
         let max_frames = ((num_tokens as f64 / 3.0 + 2.0) * 12.5).ceil() as usize;
@@ -315,7 +278,7 @@ impl Model {
 
         console_log!("[start_generation] running prompt_text...");
         let mimi_state = dispatch!(&self.inner, &mut tts_state, |m, s| {
-            m.prompt_text(s, token_ids)?;
+            m.prompt_text(s, &token_ids)?;
             m.init_mimi_state(1, 250)?
         });
         console_log!("[start_generation] prompt_text done, starting generation loop");
@@ -336,7 +299,7 @@ impl Model {
             eos_countdown: None,
             step: 0,
         });
-        Ok(())
+        Ok(num_tokens)
     }
 
     pub fn generation_step_(&mut self) -> xn::Result<Option<js_sys::Float32Array>> {
@@ -389,33 +352,24 @@ impl Model {
 
 #[wasm_bindgen]
 impl Model {
+    /// `tokenizer_json` is the contents of a `tokenizer.json` for this checkpoint's vocabulary.
     #[wasm_bindgen(constructor)]
-    pub fn new(model_weights: &[u8], quant: &str) -> Result<Model, JsError> {
-        Self::new_(model_weights, quant).map_err(|e| JsError::new(&e.to_string()))
+    pub fn new(model_weights: &[u8], tokenizer_json: &[u8], quant: &str) -> Result<Model, JsError> {
+        Self::new_(model_weights, tokenizer_json, quant).map_err(|e| JsError::new(&e.to_string()))
     }
 
     pub fn add_voice(&mut self, voice_weights: &[u8]) -> Result<usize, JsError> {
         self.add_voice_(voice_weights).map_err(|e| JsError::new(&e.to_string()))
     }
 
-    /// Prepare text for generation: capitalize, add punctuation, pad short text.
-    /// Returns [processed_text, frames_after_eos] as a JS array.
-    pub fn prepare_text(&self, text: &str) -> js_sys::Array {
-        let (processed, frames_after_eos) = prepare_text_prompt(text);
-        let arr = js_sys::Array::new();
-        arr.push(&JsValue::from_str(&processed));
-        arr.push(&JsValue::from_f64(frames_after_eos as f64));
-        arr
-    }
-
+    /// Prepares and tokenizes `text`, then runs the prompt step. Returns the token count.
     pub fn start_generation(
         &mut self,
         voice_index: usize,
-        token_ids: &[u32],
-        frames_after_eos: usize,
+        text: &str,
         temperature: f32,
-    ) -> Result<(), JsError> {
-        self.start_generation_(voice_index, token_ids, frames_after_eos, temperature)
+    ) -> Result<usize, JsError> {
+        self.start_generation_(voice_index, text, temperature)
             .map_err(|e| JsError::new(&e.to_string()))
     }
 

--- a/ptts-wasm/www/worker.js
+++ b/ptts-wasm/www/worker.js
@@ -2,7 +2,7 @@ import init, { Model, cpu_features } from './ptts_wasm.js';
 
 const HF_BASE = 'https://huggingface.co/kyutai/pocket-tts-without-voice-cloning/resolve/main';
 const HF_BASE_Q8 = 'https://huggingface.co/lmz/pocket-tts-without-voice-cloning-q8/resolve/main';
-const TOKENIZER_URL = `${HF_BASE}/tokenizer.model`;
+const TOKENIZER_URL = `${HF_BASE}/tokenizer.json`;
 
 function modelUrl(quant) {
   if (quant === 'q8') return `${HF_BASE_Q8}/tts_b6369a24.gguf`;
@@ -51,155 +51,6 @@ async function fetchWithProgress(url, label) {
   return buf;
 }
 
-// ---- Minimal protobuf decoder for sentencepiece .model files ----
-function decodeSentencepieceModel(buffer) {
-  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-  let pos = 0;
-
-  function readVarint() {
-    let result = 0, shift = 0;
-    while (pos < buffer.length) {
-      const b = buffer[pos++];
-      result |= (b & 0x7f) << shift;
-      shift += 7;
-      if ((b & 0x80) === 0) return result;
-    }
-    return result;
-  }
-
-  function readBytes(n) {
-    const data = buffer.slice(pos, pos + n);
-    pos += n;
-    return data;
-  }
-
-  function decodePiece(data) {
-    let pPos = 0, piece = '', score = 0, type = 1;
-    const pView = new DataView(data.buffer, data.byteOffset, data.byteLength);
-    while (pPos < data.length) {
-      const key = readVarIntFrom(data, pPos);
-      pPos = key.pos;
-      const fieldNum = key.val >>> 3;
-      const wireType = key.val & 0x7;
-      if (fieldNum === 1 && wireType === 2) {
-        const len = readVarIntFrom(data, pPos);
-        pPos = len.pos;
-        piece = new TextDecoder().decode(data.slice(pPos, pPos + len.val));
-        pPos += len.val;
-      } else if (fieldNum === 2 && wireType === 5) {
-        score = pView.getFloat32(pPos, true);
-        pPos += 4;
-      } else if (fieldNum === 3 && wireType === 0) {
-        const v = readVarIntFrom(data, pPos);
-        type = v.val;
-        pPos = v.pos;
-      } else {
-        if (wireType === 0) { const v = readVarIntFrom(data, pPos); pPos = v.pos; }
-        else if (wireType === 1) { pPos += 8; }
-        else if (wireType === 2) { const len = readVarIntFrom(data, pPos); pPos = len.pos + len.val; }
-        else if (wireType === 5) { pPos += 4; }
-        else break;
-      }
-    }
-    return { piece, score, type };
-  }
-
-  function readVarIntFrom(buf, p) {
-    let result = 0, shift = 0;
-    while (p < buf.length) {
-      const b = buf[p++];
-      result |= (b & 0x7f) << shift;
-      shift += 7;
-      if ((b & 0x80) === 0) return { val: result, pos: p };
-    }
-    return { val: result, pos: p };
-  }
-
-  const pieces = [];
-  while (pos < buffer.length) {
-    const key = readVarint();
-    const fieldNum = key >>> 3;
-    const wireType = key & 0x7;
-    if (fieldNum === 1 && wireType === 2) {
-      const len = readVarint();
-      const data = readBytes(len);
-      const p = decodePiece(data);
-      pieces.push(p);
-    } else {
-      if (wireType === 0) { readVarint(); }
-      else if (wireType === 1) { pos += 8; }
-      else if (wireType === 2) { const len = readVarint(); pos += len; }
-      else if (wireType === 5) { pos += 4; }
-      else break;
-    }
-  }
-  return pieces;
-}
-
-// ---- Unigram tokenizer (Viterbi) ----
-class UnigramTokenizer {
-  constructor(pieces) {
-    this.pieces = pieces;
-    this.vocab = new Map();
-    this.unkId = 0;
-    for (let i = 0; i < pieces.length; i++) {
-      const p = pieces[i];
-      if (p.type === 2) this.unkId = i;
-      if (p.type === 1 || p.type === 4) {
-        this.vocab.set(p.piece, { id: i, score: p.score });
-      }
-      if (p.type === 6) {
-        this.vocab.set(p.piece, { id: i, score: p.score });
-      }
-    }
-  }
-
-  encode(text) {
-    const normalized = '\u2581' + text.replace(/ /g, '\u2581');
-    return this._viterbi(normalized);
-  }
-
-  _viterbi(text) {
-    const n = text.length;
-    const best = new Array(n + 1);
-    best[0] = { score: 0, len: 0, id: -1 };
-    for (let i = 1; i <= n; i++) {
-      best[i] = { score: -Infinity, len: 0, id: -1 };
-    }
-
-    for (let i = 0; i < n; i++) {
-      if (best[i].score === -Infinity) continue;
-      for (let len = 1; len <= n - i && len <= 64; len++) {
-        const sub = text.substring(i, i + len);
-        const entry = this.vocab.get(sub);
-        if (entry) {
-          const newScore = best[i].score + entry.score;
-          if (newScore > best[i + len].score) {
-            best[i + len] = { score: newScore, len: len, id: entry.id };
-          }
-        }
-      }
-      if (best[i + 1].score === -Infinity) {
-        const ch = text.charCodeAt(i);
-        const byteStr = `<0x${ch.toString(16).toUpperCase().padStart(2, '0')}>`;
-        const byteEntry = this.vocab.get(byteStr);
-        const fallbackId = byteEntry ? byteEntry.id : this.unkId;
-        const fallbackScore = byteEntry ? byteEntry.score : -100;
-        best[i + 1] = { score: best[i].score + fallbackScore, len: 1, id: fallbackId };
-      }
-    }
-
-    const ids = [];
-    let p = n;
-    while (p > 0) {
-      ids.push(best[p].id);
-      p -= best[p].len;
-    }
-    ids.reverse();
-    return new Uint32Array(ids);
-  }
-}
-
 // ---- Worker state ----
 const VOICE_NAMES = ['alba', 'marius', 'javert', 'fantine', 'cosette', 'eponine', 'azelma'];
 
@@ -208,7 +59,6 @@ const VOICE_NAMES = ['alba', 'marius', 'javert', 'fantine', 'cosette', 'eponine'
 const wasmModulePromise = WebAssembly.compileStreaming(fetch('ptts_wasm_bg.wasm'));
 
 let model = null;
-let tokenizer = null;
 let voiceIndexMap = {};
 
 async function handleLoad(quant) {
@@ -216,15 +66,11 @@ async function handleLoad(quant) {
   await init(wasmModule);
   post('status', { message: 'WASM initialized. Downloading tokenizer and model...' });
 
-  const tokData = await fetchWithProgress(TOKENIZER_URL, 'Tokenizer');
-  const pieces = decodeSentencepieceModel(tokData);
-  tokenizer = new UnigramTokenizer(pieces);
-  post('status', { message: `Tokenizer loaded (${pieces.length} pieces)` });
-
+  const tokenizerJson = await fetchWithProgress(TOKENIZER_URL, 'Tokenizer');
   const modelWeights = await fetchWithProgress(modelUrl(quant), 'Model weights');
 
   post('status', { message: `Initializing model (quant=${quant})...` });
-  model = new Model(modelWeights, quant);
+  model = new Model(modelWeights, tokenizerJson, quant);
 
   for (const name of VOICE_NAMES) {
     post('status', { message: `Loading voice: ${name}...` });
@@ -240,16 +86,13 @@ async function handleLoad(quant) {
 async function handleGenerate(text, voiceName, temperature) {
   const voiceIndex = voiceIndexMap[voiceName];
 
-  const [processedText, framesAfterEos] = model.prepare_text(text);
-  const tokenIds = tokenizer.encode(processedText);
-
-  post('gen_start', { numTokens: tokenIds.length });
-
-  // Time the prompt step: `start_generation` runs `prompt_text` on the
-  // transformer state, which is the bulk of the prefill cost.
+  // Time the prompt step: `start_generation` prepares and tokenizes the text, then runs
+  // `prompt_text` on the transformer state, which is the bulk of the prefill cost.
   const promptT0 = performance.now();
-  model.start_generation(voiceIndex, tokenIds, framesAfterEos, temperature);
+  const numTokens = model.start_generation(voiceIndex, text, temperature);
   const promptMs = performance.now() - promptT0;
+
+  post('gen_start', { numTokens });
 
   let step = 0;
   let stepMsTotal = 0;

--- a/ptts-ws-server/Cargo.toml
+++ b/ptts-ws-server/Cargo.toml
@@ -19,14 +19,12 @@ futures-util = { workspace = true }
 half = { workspace = true }
 hf-hub = { workspace = true }
 kaudio = { workspace = true }
-ptts = { workspace = true }
+ptts = { workspace = true, features = ["hf"] }
 rand = { workspace = true, features = ["std_rng"] }
 rand_distr = { workspace = true }
 rubato = { workspace = true }
-sentencepiece = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokenizers = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }

--- a/ptts-ws-server/src/model.rs
+++ b/ptts-ws-server/src/model.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, Result};
+use ptts::tok::Tok;
 use ptts::tts_model::{TTSConfig, TTSModel, TTSState};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -29,43 +30,6 @@ impl ptts::flow_lm::Rng for StdRng {
     fn sample(&mut self) -> f32 {
         use rand::Rng;
         self.inner.sample(self.distr)
-    }
-}
-
-pub enum Tok {
-    Sp(std::sync::Arc<sentencepiece::SentencePieceProcessor>),
-    Hf(Box<tokenizers::Tokenizer>),
-}
-
-impl From<sentencepiece::SentencePieceProcessor> for Tok {
-    fn from(sp: sentencepiece::SentencePieceProcessor) -> Self {
-        Tok::Sp(std::sync::Arc::new(sp))
-    }
-}
-
-impl From<tokenizers::Tokenizer> for Tok {
-    fn from(tok: tokenizers::Tokenizer) -> Self {
-        Tok::Hf(Box::new(tok))
-    }
-}
-
-impl ptts::Tokenizer for Tok {
-    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
-        let tokens = match self {
-            Tok::Sp(sp) => {
-                sp.encode(text).map_err(xn::Error::wrap)?.into_iter().map(|v| v.id).collect()
-            }
-            Tok::Hf(tok) => tok.encode(text, false).map_err(xn::Error::wrap)?.get_ids().to_vec(),
-        };
-        Ok(tokens)
-    }
-
-    fn decode(&self, ids: &[u32]) -> xn::Result<String> {
-        let decoded = match self {
-            Tok::Sp(sp) => sp.decode_piece_ids(ids).map_err(xn::Error::wrap)?,
-            Tok::Hf(tok) => tok.decode(ids, true).map_err(xn::Error::wrap)?,
-        };
-        Ok(decoded)
     }
 }
 
@@ -158,7 +122,7 @@ impl<Q: BackendQ> LoadedModel<Q> {
 
         let model_path = repo.get("model.q8.gguf")?;
         tracing::info!(?model_path, "model weights ready");
-        let tokenizer_path = repo.get("tokenizer.model")?;
+        let tokenizer_path = repo.get("tokenizer.json")?;
 
         let mut voices: HashMap<String, Tensor<Q::T, Q::B>> = HashMap::new();
         let default_voice = load_voice_embedding(&repo.get("default-voice.safetensors")?, dev)
@@ -176,7 +140,7 @@ impl<Q: BackendQ> LoadedModel<Q> {
         let repo = crate::utils::HfRepo::model(DEFAULT_REPO_ID)?;
         let model_path = repo.get(DEFAULT_MODEL_FILE)?;
         tracing::info!(?model_path, "model weights ready");
-        let tokenizer_path = repo.get("tokenizer.model")?;
+        let tokenizer_path = repo.get("tokenizer.json")?;
 
         let mut voices: HashMap<String, Tensor<Q::T, Q::B>> = HashMap::new();
         for &voice in VOICES {
@@ -218,7 +182,7 @@ impl<Q: BackendQ> LoadedModel<Q> {
                 "model file not found in directory {parent_dir:?}; expected model.safetensors or model.gguf"
             );
         };
-        let tokenizer_path = parent_dir.join("tokenizer.model");
+        let tokenizer_path = parent_dir.join("tokenizer.json");
         let mut voices: HashMap<String, Tensor<Q::T, Q::B>> = HashMap::new();
         for voice in parent_dir.join("voices").read_dir()? {
             let voice = match voice {
@@ -317,18 +281,7 @@ pub fn load_ptts<Q: BackendQ>(
         load_voices_from_dir::<Q>(voice_dir, &dev, &mut m.voices);
         tracing::info!(num_voices = m.voices.len(), "voice embeddings loaded (incl. voice-dir)");
     }
-    let tokenizer_path = m.tokenizer_path.to_str().context("invalid tokenizer path")?;
-    let tokenizer = if tokenizer_path.ends_with(".model") {
-        tracing::info!("loading SentencePiece tokenizer");
-        let sp = sentencepiece::SentencePieceProcessor::open(tokenizer_path)
-            .with_context(|| format!("failed to open tokenizer at {tokenizer_path}"))?;
-        Tok::Sp(sp.into())
-    } else {
-        tracing::info!("loading Hugging Face tokenizer");
-        let tok = tokenizers::Tokenizer::from_file(tokenizer_path)
-            .map_err(|e| anyhow::format_err!("failed to load tokenizer: {e}"))?;
-        Tok::Hf(Box::new(tok))
-    };
+    let tokenizer = Tok::open(&m.tokenizer_path)?;
 
     let vb = if m.model_path.extension().and_then(|v| v.to_str()) == Some("gguf") {
         let reader = std::fs::File::open(&m.model_path)?;

--- a/ptts/Cargo.toml
+++ b/ptts/Cargo.toml
@@ -26,10 +26,12 @@ half = { workspace = true }
 hf-hub = { workspace = true }
 safetensors = { workspace = true }
 rubato = { workspace = true }
-libc = { workspace = true }
 serde_json = { workspace = true }
 symphonia = { workspace = true }
 tracing-chrome = { workspace = true }
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = { workspace = true }
 
 [features]
 default = []

--- a/ptts/Cargo.toml
+++ b/ptts/Cargo.toml
@@ -17,7 +17,7 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-sentencepiece = { workspace = true, optional = true }
+tokenizers = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -38,11 +38,12 @@ vulkan = ["xn/vulkan"]
 metal = ["xn/metal"]
 webgpu = ["xn/webgpu"]
 accelerate = ["xn/accelerate"]
-sp = ["dep:sentencepiece"]
+# Hugging Face `tokenizers` support, i.e. the `ptts::tok` module.
+hf = ["dep:tokenizers"]
 
 [[example]]
 name = "pocket_tts"
-required-features = ["sp"]
+required-features = ["hf"]
 
 [[example]]
 name = "bench"

--- a/ptts/Cargo.toml
+++ b/ptts/Cargo.toml
@@ -47,7 +47,7 @@ required-features = ["hf"]
 
 [[example]]
 name = "bench"
-required-features = ["sp"]
+required-features = ["hf"]
 
 [[example]]
 name = "quantize"

--- a/ptts/examples/bench.rs
+++ b/ptts/examples/bench.rs
@@ -11,7 +11,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use model_helpers::{SpTokenizer, max_frames_for};
+use model_helpers::max_frames_for;
+use ptts::tok::Tok;
 use ptts::tts_model::{TTSConfig, TTSModel, TTSState};
 use xn::{BackendQ, Tensor};
 
@@ -30,7 +31,7 @@ struct Args {
     #[arg(long)]
     config: std::path::PathBuf,
 
-    /// SentencePiece tokenizer. Defaults to `tokenizer.model` next to the config.
+    /// Tokenizer json. Defaults to `tokenizer.json` next to the config.
     #[arg(long)]
     tokenizer: Option<std::path::PathBuf>,
 
@@ -232,12 +233,12 @@ impl Bench<'_> {
         let tokenizer_path = match args.tokenizer.clone() {
             Some(path) => path,
             None => {
-                args.config.parent().context("config path has no parent")?.join("tokenizer.model")
+                args.config.parent().context("config path has no parent")?.join("tokenizer.json")
             }
         };
 
         let t_load = Instant::now();
-        let tokenizer = SpTokenizer::open(&tokenizer_path)?;
+        let tokenizer = Tok::open(&tokenizer_path)?;
         let vb = model_helpers::load_weights::<Q>(&args.model, &dev)?;
         let model: TTSModel<Q> = TTSModel::load(&vb, Box::new(tokenizer), &cfg)?;
         vb.check_all_used_with_ignore(model_helpers::is_unused_by_tts_model)?;

--- a/ptts/examples/model_helpers.rs
+++ b/ptts/examples/model_helpers.rs
@@ -94,25 +94,3 @@ pub fn load_voice_emb<Q: BackendQ>(
 pub fn max_frames_for(num_tokens: usize) -> usize {
     ((num_tokens as f64 / 3.0 + 2.0) * 12.5).ceil() as usize
 }
-
-#[cfg(feature = "sp")]
-pub struct SpTokenizer(pub sentencepiece::SentencePieceProcessor);
-
-#[cfg(feature = "sp")]
-impl SpTokenizer {
-    pub fn open(path: &std::path::Path) -> Result<Self> {
-        let path = path.to_str().context("invalid tokenizer path")?;
-        Ok(Self(sentencepiece::SentencePieceProcessor::open(path)?))
-    }
-}
-
-#[cfg(feature = "sp")]
-impl ptts::Tokenizer for SpTokenizer {
-    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
-        Ok(self.0.encode(text).map_err(xn::Error::wrap)?.into_iter().map(|v| v.id).collect())
-    }
-
-    fn decode(&self, tokens: &[u32]) -> xn::Result<String> {
-        self.0.decode_piece_ids(tokens).map_err(xn::Error::wrap)
-    }
-}

--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -230,19 +230,28 @@ fn main() -> Result<()> {
         run_cpu(args)?;
     }
 
-    tracing::info!("peak RSS: {:.2} MB", peak_rss_mb());
+    match peak_rss_mb() {
+        Some(mb) => tracing::info!("peak RSS: {mb:.2} MB"),
+        None => tracing::info!("peak RSS: unavailable on this platform"),
+    }
 
     Ok(())
 }
 
-fn peak_rss_mb() -> f64 {
+#[cfg(unix)]
+fn peak_rss_mb() -> Option<f64> {
     let mut usage = std::mem::MaybeUninit::uninit();
     let maxrss = unsafe {
         libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr());
         usage.assume_init().ru_maxrss as f64
     };
     // ru_maxrss is in bytes on macOS but kilobytes on Linux.
-    if cfg!(target_os = "macos") { maxrss / (1024.0 * 1024.0) } else { maxrss / 1024.0 }
+    Some(if cfg!(target_os = "macos") { maxrss / (1024.0 * 1024.0) } else { maxrss / 1024.0 })
+}
+
+#[cfg(not(unix))]
+fn peak_rss_mb() -> Option<f64> {
+    None
 }
 
 enum Rng {

--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -83,7 +83,7 @@ enum Voice {
     Audio(String),
 }
 
-fn download_files(voice: &str) -> Result<(std::path::PathBuf, std::path::PathBuf, Voice)> {
+fn download_files(voice: &str) -> Result<(std::path::PathBuf, Option<std::path::PathBuf>, Voice)> {
     use hf_hub::{Repo, RepoType, api::sync::Api};
     let repo_id = "kyutai/pocket-tts";
     tracing::info!(?repo_id, "downloading weights...");
@@ -93,12 +93,9 @@ fn download_files(voice: &str) -> Result<(std::path::PathBuf, std::path::PathBuf
     let model_path = repo.get("tts_b6369a24.safetensors").context("model weights not found")?;
     tracing::info!(?model_path, "model weights downloaded");
 
-    // The repo ships a SentencePiece `tokenizer.model`, which needs converting once; `--tokenizer`
-    // then points at the result.
-    let tokenizer_path = repo.get("tokenizer.json").context(
-        "no tokenizer.json in the repo: convert its tokenizer.model with \
-         `uv run scripts/convert-tokenizer.py` and pass the result with --tokenizer",
-    )?;
+    // The repo ships a SentencePiece `tokenizer.model`, which needs converting once, so a
+    // `tokenizer.json` is not there to be had yet; `--tokenizer` points at the converted one.
+    let tokenizer_path = repo.get("tokenizer.json").ok();
     tracing::info!(?tokenizer_path, "tokenizer downloaded");
 
     let voice = if VOICES.contains(&voice) {
@@ -313,7 +310,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
                 None => parent.join("model.safetensors"),
                 Some(p) => std::path::PathBuf::from_str(p)?,
             };
-            let tokenizer_path = parent.join("tokenizer.json");
+            let tokenizer_path = Some(parent.join("tokenizer.json"));
             tracing::info!(?config, "using local config");
             let config: ptts::tts_model::TTSConfig =
                 serde_json::from_str(&std::fs::read_to_string(config)?)?;
@@ -344,7 +341,11 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
         }
     };
 
-    let tokenizer = Tok::open(args.tokenizer.as_deref().unwrap_or(&tokenizer_path))?;
+    let tokenizer_path = args.tokenizer.as_deref().or(tokenizer_path.as_deref()).context(
+        "no tokenizer.json alongside the weights: convert the checkpoint's tokenizer.model with \
+         `uv run scripts/convert-tokenizer.py` and pass the result with --tokenizer",
+    )?;
+    let tokenizer = Tok::open(tokenizer_path)?;
     let text = match args.lang.as_deref() {
         None => std::borrow::Cow::Borrowed(args.text.as_str()),
         Some(lang) => {

--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -5,7 +5,8 @@ mod model_helpers;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use model_helpers::{SpTokenizer, max_frames_for};
+use model_helpers::max_frames_for;
+use ptts::tok::Tok;
 use ptts::tts_model::{
     MimiEnc, TTSConfig, TTSModel, prepare_text_prompt, split_into_best_sentences,
 };
@@ -50,6 +51,11 @@ struct Args {
     #[arg(long)]
     quant: Option<String>,
 
+    /// Path to a `tokenizer.json`, as produced by `scripts/convert-tokenizer.py`. Defaults to the
+    /// one shipped next to the weights.
+    #[arg(long)]
+    tokenizer: Option<std::path::PathBuf>,
+
     #[arg(long)]
     chrome_tracing: bool,
 
@@ -87,7 +93,12 @@ fn download_files(voice: &str) -> Result<(std::path::PathBuf, std::path::PathBuf
     let model_path = repo.get("tts_b6369a24.safetensors").context("model weights not found")?;
     tracing::info!(?model_path, "model weights downloaded");
 
-    let tokenizer_path = repo.get("tokenizer.model").context("tokenizer not found")?;
+    // The repo ships a SentencePiece `tokenizer.model`, which needs converting once; `--tokenizer`
+    // then points at the result.
+    let tokenizer_path = repo.get("tokenizer.json").context(
+        "no tokenizer.json in the repo: convert its tokenizer.model with \
+         `uv run scripts/convert-tokenizer.py` and pass the result with --tokenizer",
+    )?;
     tracing::info!(?tokenizer_path, "tokenizer downloaded");
 
     let voice = if VOICES.contains(&voice) {
@@ -302,7 +313,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
                 None => parent.join("model.safetensors"),
                 Some(p) => std::path::PathBuf::from_str(p)?,
             };
-            let tokenizer_path = parent.join("tokenizer.model");
+            let tokenizer_path = parent.join("tokenizer.json");
             tracing::info!(?config, "using local config");
             let config: ptts::tts_model::TTSConfig =
                 serde_json::from_str(&std::fs::read_to_string(config)?)?;
@@ -333,7 +344,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
         }
     };
 
-    let tokenizer = SpTokenizer::open(&tokenizer_path)?;
+    let tokenizer = Tok::open(args.tokenizer.as_deref().unwrap_or(&tokenizer_path))?;
     let text = match args.lang.as_deref() {
         None => std::borrow::Cow::Borrowed(args.text.as_str()),
         Some(lang) => {

--- a/ptts/src/lib.rs
+++ b/ptts/src/lib.rs
@@ -9,6 +9,8 @@ pub mod preprocess;
 pub mod resample;
 pub mod rope;
 pub mod seanet;
+#[cfg(feature = "hf")]
+pub mod tok;
 pub mod transformer;
 pub mod tts_model;
 pub mod utils;

--- a/ptts/src/tok.rs
+++ b/ptts/src/tok.rs
@@ -7,13 +7,7 @@
 //! Available with the `hf` feature.
 
 /// A Hugging Face tokenizer.
-pub struct Tok(Box<tokenizers::Tokenizer>);
-
-impl From<tokenizers::Tokenizer> for Tok {
-    fn from(tok: tokenizers::Tokenizer) -> Self {
-        Tok(Box::new(tok))
-    }
-}
+pub struct Tok(tokenizers::Tokenizer);
 
 impl Tok {
     /// Opens a `tokenizer.json`. A SentencePiece `.model` path — or a missing `tokenizer.json`
@@ -30,8 +24,16 @@ impl Tok {
             }
         }
         tracing::info!(?path, "loading Hugging Face tokenizer");
-        let tok = tokenizers::Tokenizer::from_file(path).map_err(xn::Error::wrap)?;
-        Ok(Tok::from(tok))
+        let tok = tokenizers::Tokenizer::from_file(path)
+            .map_err(|e| xn::Error::wrap(e).with_path(path))?;
+        Ok(Tok(tok))
+    }
+
+    /// Loads the contents of a `tokenizer.json`, for callers with no filesystem to read it from
+    /// (the wasm demo fetches it over the network).
+    pub fn from_bytes(json: &[u8]) -> xn::Result<Self> {
+        let tok = tokenizers::Tokenizer::from_bytes(json).map_err(xn::Error::wrap)?;
+        Ok(Tok(tok))
     }
 }
 
@@ -57,6 +59,16 @@ impl crate::Tokenizer for Tok {
 
 #[cfg(test)]
 mod tests {
+    const MINIMAL: &str = r#"{"version":"1.0","added_tokens":[],
+      "model":{"type":"Unigram","unk_id":0,"vocab":[["<unk>",0.0],["ab",-1.0],["c",-2.0]]}}"#;
+
+    #[test]
+    fn from_bytes_reads_a_tokenizer_json() {
+        use crate::Tokenizer as _;
+        let tok = super::Tok::from_bytes(MINIMAL.as_bytes()).unwrap();
+        assert_eq!(tok.encode("abc").unwrap(), [1, 2]);
+    }
+
     #[test]
     fn sentencepiece_models_point_at_the_converter() {
         let err = super::Tok::open(std::path::Path::new("weights/tokenizer.model"))

--- a/ptts/src/tok.rs
+++ b/ptts/src/tok.rs
@@ -1,0 +1,67 @@
+//! A [`crate::Tokenizer`] backed by Hugging Face [`tokenizers`].
+//!
+//! The published checkpoints ship a SentencePiece `tokenizer.model`, which this crate does not
+//! read: `scripts/convert-tokenizer.py` turns one into an equivalent `tokenizer.json` (same ids,
+//! same round-trip, checked against `sentencepiece` as it converts) and [`Tok::open`] loads that.
+//!
+//! Available with the `hf` feature.
+
+/// A Hugging Face tokenizer.
+pub struct Tok(Box<tokenizers::Tokenizer>);
+
+impl From<tokenizers::Tokenizer> for Tok {
+    fn from(tok: tokenizers::Tokenizer) -> Self {
+        Tok(Box::new(tok))
+    }
+}
+
+impl Tok {
+    /// Opens a `tokenizer.json`. A SentencePiece `.model` path — or a missing `tokenizer.json`
+    /// sitting next to one — is refused with a pointer at the conversion script: every checkpoint
+    /// has its own vocabulary, so there is no tokenizer to fall back to.
+    pub fn open(path: &std::path::Path) -> xn::Result<Self> {
+        if path.extension().and_then(|v| v.to_str()) == Some("model") {
+            return Err(needs_conversion(path));
+        }
+        if !path.is_file() {
+            let sp = path.with_file_name("tokenizer.model");
+            if sp.is_file() {
+                return Err(needs_conversion(&sp));
+            }
+        }
+        tracing::info!(?path, "loading Hugging Face tokenizer");
+        let tok = tokenizers::Tokenizer::from_file(path).map_err(xn::Error::wrap)?;
+        Ok(Tok::from(tok))
+    }
+}
+
+fn needs_conversion(sp: &std::path::Path) -> xn::Error {
+    let sp = sp.display();
+    xn::Error::msg(format!(
+        "{sp} is a SentencePiece model, which ptts does not read; convert it once with \
+         `uv run scripts/convert-tokenizer.py {sp}` and pass the tokenizer.json it writes"
+    ))
+    .with_path(sp.to_string())
+}
+
+impl crate::Tokenizer for Tok {
+    fn encode(&self, text: &str) -> xn::Result<Vec<u32>> {
+        let encoded = self.0.encode(text, false).map_err(xn::Error::wrap)?;
+        Ok(encoded.get_ids().to_vec())
+    }
+
+    fn decode(&self, ids: &[u32]) -> xn::Result<String> {
+        self.0.decode(ids, true).map_err(xn::Error::wrap)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn sentencepiece_models_point_at_the_converter() {
+        let err = super::Tok::open(std::path::Path::new("weights/tokenizer.model"))
+            .err()
+            .expect("a .model path is not a tokenizer.json");
+        assert!(err.to_string().contains("convert-tokenizer.py"), "{err}");
+    }
+}


### PR DESCRIPTION
# Drop the SentencePiece dependency

## Summary

`sentencepiece` is gone from the workspace. All four frontends now tokenize through Hugging Face
`tokenizers`: the `pocket_tts` example, `ptts-pyo3`, `ptts-ws-server` and `ptts-wasm`.

The three Rust frontends each carried a private copy of the same `Tok` enum with the same
`Sp`/`Hf` arms and the same trait impl. They now share one HF-only `ptts::tok::Tok`, behind a new
`hf` feature that replaces `sp`.

`ptts-wasm` tokenized in JavaScript, and no longer does. `www/worker.js` decoded the SentencePiece
protobuf by hand and ran its own Viterbi unigram; both are deleted, 293 -> 136 lines. It fetches
the repo's `tokenizer.json` the same way it fetches weights and voices, hands the bytes to
`Model::new`, and passes *text* to `start_generation`, which returns the token count. That also
retires the `PresetTokenizer` / `SharedTokenizer` shims in `src/lib.rs` (net −46 lines): the model
owns a real tokenizer now, reachable through `flow_lm.conditioner.tokenize` the way pyo3 and the
ws-server already reach it.

## Tokenizer resolution

A wrong-but-loadable tokenizer produces plausible audio from the wrong ids, so nothing falls back
silently. `Tok::open` refuses a `.model` path — and a missing `tokenizer.json` sitting next to
one — with the fix in the message:

    Error: path: ".../tokenizer.model" .../tokenizer.model is a SentencePiece model, which ptts
    does not read; convert it once with `uv run scripts/convert-tokenizer.py
    .../tokenizer.model` and pass the tokenizer.json it writes

| Load path | Tokenizer |
|---|---|
| `pocket_tts --tokenizer <path>` | that path, ahead of everything below |
| `pocket_tts --config <cfg>` | `tokenizer.json` beside the config |
| `pocket_tts` default | `tokenizer.json` from `kyutai/pocket-tts` if hosted, else `--tokenizer` |
| `ptts-pyo3`, `ptts-ws-server` | `tokenizer.json` from the HF repo or beside the config |
| `ptts-wasm` demo | `tokenizer.json` from the checkpoint's HF repo |

## Blocked on hosting the json

No repo hosts a `tokenizer.json` today, `kyutai/pocket-tts`,
`kyutai/pocket-tts-without-voice-cloning` and `lmz/pocket-tts-without-voice-cloning-q8` ship only
`tokenizer.model`, as do all thirteen `languages/*` variants. Converting and uploading one next to
the weights is a prerequisite for this branch: