### PR TITLE
Feat/synth on loader

### DIFF
--- a/ptts/Cargo.toml
+++ b/ptts/Cargo.toml
@@ -17,9 +17,14 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+safetensors = { workspace = true }
+serde_json = { workspace = true }
+# Optional: `hf-hub` for `ModelSource::Hub` (pulls in ureq, so it must stay out
+# of the wasm build), and one of `sentencepiece` / `tokenizers` for reading a
+# tokenizer out of a checkpoint.
+hf-hub = { workspace = true, optional = true }
 sentencepiece = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
-safetensors = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -44,10 +49,16 @@ accelerate = ["xn/accelerate"]
 sp = ["dep:sentencepiece"]
 # Hugging Face `tokenizers` support in `ptts::tok`.
 hf = ["dep:tokenizers"]
+# Download checkpoints from the Hugging Face Hub (`ModelSource::Hub`).
+hub = ["dep:hf-hub"]
+
+[[example]]
+name = "say"
+required-features = ["sp", "hub"]
 
 [[example]]
 name = "pocket_tts"
-required-features = ["sp"]
+required-features = ["sp", "hub"]
 
 [[example]]
 name = "bench"

--- a/ptts/examples/bench.rs
+++ b/ptts/examples/bench.rs
@@ -11,8 +11,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use model_helpers::max_frames_for;
 use ptts::flow_lm::NormalRng;
+use ptts::plan::{EosPolicy, frame_budget};
 use ptts::tok::Tok;
 use ptts::tts_model::{TTSConfig, TTSModel, TTSState};
 use xn::{BackendQ, Tensor};
@@ -97,6 +97,7 @@ fn one<Q: BackendQ>(
     base_state: &TTSState<Q>,
     chunks: &[(Vec<u32>, usize)],
     args: &Args,
+    frame_rate: f64,
 ) -> Result<Run> {
     let dev = model.device();
     let ldim = model.flow_lm.ldim;
@@ -116,9 +117,9 @@ fn one<Q: BackendQ>(
         // BOS marker: an all-NaN latent.
         let nan: Tensor<f32, Q::B> = Tensor::from_vec(vec![f32::NAN; ldim], (1, 1, ldim), dev)?;
         let mut prev_latent = nan.to::<Q::T>()?;
-        let mut eos_countdown: Option<usize> = None;
+        let mut eos = EosPolicy::new(*frames_after_eos);
 
-        for _ in 0..max_frames_for(tokens.len()) {
+        for _ in 0..frame_budget(tokens.len(), frame_rate) {
             let frame_start = Instant::now();
             let (next_latent, is_eos) = model.generate_step(&mut state, &prev_latent, &mut rng)?;
             let sampled = Instant::now();
@@ -134,14 +135,8 @@ fn one<Q: BackendQ>(
                 samples += pcm.len();
             }
 
-            if is_eos && eos_countdown.is_none() {
-                eos_countdown = Some(*frames_after_eos);
-            }
-            if let Some(countdown) = eos_countdown.as_mut() {
-                if *countdown == 0 {
-                    break;
-                }
-                *countdown -= 1;
+            if eos.should_stop(is_eos) {
+                break;
             }
             prev_latent = next_latent;
         }
@@ -250,7 +245,9 @@ impl Bench<'_> {
         let voice_len = voice_emb.dim(1usize)?;
         let seq_budget = chunks
             .iter()
-            .map(|(tokens, _)| voice_len + tokens.len() + max_frames_for(tokens.len()))
+            .map(|(tokens, _)| {
+                voice_len + tokens.len() + frame_budget(tokens.len(), cfg.mimi.frame_rate)
+            })
             .max()
             .unwrap_or(voice_len);
         let t_voice = Instant::now();
@@ -259,11 +256,11 @@ impl Bench<'_> {
         let voice_ms = ms(t_voice.elapsed());
 
         for _ in 0..args.warmup {
-            one(&model, &base_state, &chunks, args)?;
+            one(&model, &base_state, &chunks, args, cfg.mimi.frame_rate)?;
         }
         let mut runs = Vec::with_capacity(args.iters);
         for i in 0..args.iters {
-            let r = one(&model, &base_state, &chunks, args)?;
+            let r = one(&model, &base_state, &chunks, args, cfg.mimi.frame_rate)?;
             if args.per_iter {
                 println!(
                     "iter {i:>3}: total {:>8.2}ms  ttfa {:>7.2}ms  frames {:>4}",

--- a/ptts/examples/model_helpers.rs
+++ b/ptts/examples/model_helpers.rs
@@ -1,14 +1,10 @@
 //! Bits the examples share that are not worth a place in the library.
 //!
-//! Weight loading, key remapping and voice-embedding loading now live in `ptts::loader`, and
-//! the tokenizer in `ptts::tok`; this re-exports them so each example has one place to look.
+//! Weight loading, key remapping and voice-embedding loading now live in `ptts::loader`, the
+//! tokenizer in `ptts::tok` and the frame budget in `ptts::plan`; this re-exports the first two
+//! so each example has one place to look.
 #![allow(dead_code, unused_imports)]
 
 pub use ptts::loader::{is_unused_by_tts_model, load_voice_emb, load_weights, remap_key};
 #[cfg(feature = "sp")]
 pub use ptts::tok::Tok;
-
-/// Frames an utterance of `num_tokens` tokens is allowed to generate before it is cut off.
-pub fn max_frames_for(num_tokens: usize) -> usize {
-    ((num_tokens as f64 / 3.0 + 2.0) * 12.5).ceil() as usize
-}

--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -1,195 +1,79 @@
+//! Generate speech from text on the command line.
+//!
+//! ```text
+//! cargo run --release --example pocket_tts --features sp,hub -- "hello world" -o out.wav
+//! ```
+//!
+//! Everything between the text and the WAV file is [`ptts::synth::Synth`]; what
+//! is left here is argument parsing, audio file decoding for `--voice <file>`,
+//! and the timing report.
+
 #[path = "audio_helpers.rs"]
 mod audio_helpers;
-#[path = "model_helpers.rs"]
-mod model_helpers;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
-use model_helpers::max_frames_for;
-use ptts::flow_lm::NormalRng;
-use ptts::tok::Tok;
-use ptts::tts_model::{
-    MimiEnc, TTSConfig, TTSModel, prepare_text_prompt, split_into_best_sentences,
-};
-use xn::Tensor;
+use ptts::synth::{DeviceKind, Quant, SpeechOptions, Synth};
+use std::str::FromStr;
 
 #[derive(Parser, Debug)]
-#[command(name = "pocket-tts")]
-#[command(about = "Generate speech from text using Pocket TTS")]
+#[command(name = "pocket-tts", about = "Generate speech from text using Pocket TTS")]
 struct Args {
-    /// Text to synthesize
+    /// Text to synthesize.
     text: String,
 
-    #[arg(long)]
-    config: Option<String>,
-
-    #[arg(long)]
-    weights: Option<String>,
-
-    #[arg(long)]
-    cfg_coef: Option<f32>,
-
-    /// Output WAV file path
+    /// Output WAV file path.
     #[arg(short, long, default_value = "output.wav")]
     output: std::path::PathBuf,
 
-    /// Voice to use
+    /// Voice: a bundled voice id, a path to a voice `.safetensors`, or a path to
+    /// a ~10s audio file to clone. Defaults to the first bundled voice.
     #[arg(short, long)]
     voice: Option<String>,
 
-    /// Sampling temperature
+    /// Sampling temperature.
     #[arg(short, long, default_value_t = 0.7)]
     temperature: f32,
 
-    /// Sampling seed
+    /// Sampling seed.
     #[arg(short, long, default_value_t = 4242424242424242)]
     seed: u64,
 
-    /// Use the cpu device even if a gpu backend is available
-    #[arg(long, default_value_t = false)]
-    cpu: bool,
+    /// Load from a local directory holding config.json, weights, tokenizer and
+    /// voices/ instead of downloading from the Hugging Face Hub.
+    #[arg(long)]
+    dir: Option<std::path::PathBuf>,
 
+    /// Device to run on: auto, cpu, cuda, vulkan or metal.
+    #[arg(long, default_value = "auto")]
+    device: String,
+
+    /// Weight format for the flow-LM linears, e.g. q8_0 or q4k. CPU only.
     #[arg(long)]
     quant: Option<String>,
 
+    /// Classifier-free guidance coefficient. 1.0 disables it.
+    #[arg(long)]
+    cfg_coef: Option<f32>,
+
+    /// Replay noise from a JSON array of floats instead of sampling it, so a
+    /// run can be compared against the reference implementation step for step.
+    #[arg(long)]
+    rng_values: Option<std::path::PathBuf>,
+
+    /// Write a Chrome trace of the run to ./trace-<timestamp>.json.
     #[arg(long)]
     chrome_tracing: bool,
 
-    #[arg(long)]
-    rng_values: Option<String>,
-
-    #[arg(long)]
-    wait_to_decode: bool,
-
-    /// Decode every queued frame in one call instead of one frame per call.
-    #[arg(long, default_value_t = false)]
-    decode_batching: bool,
-
-    /// Number of CPU threads for tensor ops.
+    /// Number of CPU threads for tensor ops. Defaults to one per logical core.
     #[arg(long)]
     threads: Option<usize>,
 
-    #[arg(long)]
-    pad_to: Option<usize>,
-
     /// Normalize the text for this language before tokenizing: `en`, `fr`, `de`, `es` or `pt`.
-    /// Drops characters the model never saw and spells out `@`, `+` and `=`. Omitted, the text
-    /// is tokenized exactly as given.
     #[arg(long)]
     lang: Option<String>,
 }
 
-const VOICES: &[&str] =
-    &["alba", "marius", "javert", "jean", "fantine", "cosette", "eponine", "azelma"];
-
-enum Voice {
-    Safetensors(std::path::PathBuf),
-    Audio(String),
-}
-
-fn download_files(voice: &str) -> Result<(std::path::PathBuf, std::path::PathBuf, Voice)> {
-    use hf_hub::{Repo, RepoType, api::sync::Api};
-    let repo_id = "kyutai/pocket-tts";
-    tracing::info!(?repo_id, "downloading weights...");
-    let api = Api::new()?;
-    let repo = api.repo(Repo::new(repo_id.to_string(), RepoType::Model));
-
-    let model_path = repo.get("tts_b6369a24.safetensors").context("model weights not found")?;
-    tracing::info!(?model_path, "model weights downloaded");
-
-    let tokenizer_path = repo.get("tokenizer.model").context("tokenizer not found")?;
-    tracing::info!(?tokenizer_path, "tokenizer downloaded");
-
-    let voice = if VOICES.contains(&voice) {
-        let voice_file = format!("embeddings/{voice}.safetensors");
-        let voice_path = repo
-            .get(&voice_file)
-            .with_context(|| format!("voice embedding '{voice}' not found"))?;
-        tracing::info!(?voice_path, "voice embedding downloaded");
-        Voice::Safetensors(voice_path)
-    } else if voice.ends_with(".safetensors") {
-        let voice_path = std::path::PathBuf::from(voice);
-        if !voice_path.exists() {
-            anyhow::bail!("voice embedding file '{}' not found", voice_path.display());
-        }
-        Voice::Safetensors(voice_path)
-    } else {
-        Voice::Audio(voice.to_string())
-    };
-    Ok((model_path, tokenizer_path, voice))
-}
-
-fn init_tracing(chrome_tracing: bool) -> Option<tracing_chrome::FlushGuard> {
-    use tracing_subscriber::{EnvFilter, prelude::*};
-
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-
-    if chrome_tracing {
-        let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new().build();
-        tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::Layer::new().with_target(false))
-            .with(chrome_layer)
-            .with(filter)
-            .init();
-        Some(guard)
-    } else {
-        tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::Layer::new().with_target(false))
-            .with(filter)
-            .init();
-        None
-    }
-}
-
-fn run_cpu(args: Args) -> Result<()> {
-    match args.quant.as_deref() {
-        None => {
-            tracing::info!("using cpu backend");
-            run_for_device::<xn::Unquantized<f32, _>>(args, xn::CPU)
-        }
-        Some("q8" | "q8_0") => {
-            tracing::info!("using cpu q8 backend");
-            run_for_device::<xn::quantized::Q80F32>(args, xn::CPU)
-        }
-        Some("q8_1") => {
-            tracing::info!("using cpu q8_1 backend");
-            run_for_device::<xn::quantized::Q81F32>(args, xn::CPU)
-        }
-        Some("q8k") => {
-            tracing::info!("using cpu q8k backend");
-            run_for_device::<xn::quantized::Q8kF32>(args, xn::CPU)
-        }
-        Some("q6k") => {
-            tracing::info!("using cpu q6k backend");
-            run_for_device::<xn::quantized::Q6kF32>(args, xn::CPU)
-        }
-        Some("q5" | "q5_0") => {
-            tracing::info!("using cpu q5 backend");
-            run_for_device::<xn::quantized::Q50F32>(args, xn::CPU)
-        }
-        Some("q5_1") => {
-            tracing::info!("using cpu q5_1 backend");
-            run_for_device::<xn::quantized::Q51F32>(args, xn::CPU)
-        }
-        Some("q5k") => {
-            tracing::info!("using cpu q5k backend");
-            run_for_device::<xn::quantized::Q5kF32>(args, xn::CPU)
-        }
-        Some("q4" | "q4_0") => {
-            tracing::info!("using cpu q4 backend");
-            run_for_device::<xn::quantized::Q40F32>(args, xn::CPU)
-        }
-        Some("q4_1") => {
-            tracing::info!("using cpu q4_1 backend");
-            run_for_device::<xn::quantized::Q41F32>(args, xn::CPU)
-        }
-        Some("q4k") => {
-            tracing::info!("using cpu q4k backend");
-            run_for_device::<xn::quantized::Q4kF32>(args, xn::CPU)
-        }
-        Some(other) => anyhow::bail!("unsupported quantization option '{other}'"),
-    }
-}
 fn main() -> Result<()> {
     let args = Args::parse();
     if let Some(threads) = args.threads {
@@ -197,50 +81,148 @@ fn main() -> Result<()> {
         xn::set_num_threads(threads);
     }
     let _guard = init_tracing(args.chrome_tracing);
+    tracing::info!(
+        "avx: {}, neon: {}, simd128: {}, f16c: {}",
+        xn::with_avx(),
+        xn::with_neon(),
+        xn::with_simd128(),
+        xn::with_f16c()
+    );
 
-    #[cfg(feature = "cuda")]
-    {
-        if args.cpu {
-            run_cpu(args)?;
-        } else {
-            tracing::info!("using cuda backend");
-            let dev = xn::cuda_backend::Device::new(0)?;
-            unsafe {
-                dev.disable_event_tracking();
-            }
-            run_for_device::<xn::Unquantized<half::bf16, _>>(args, dev)?;
-        }
+    let mut builder = Synth::builder()
+        .device(DeviceKind::parse(&args.device)?)
+        .temperature(args.temperature)
+        .seed(args.seed);
+    if let Some(dir) = args.dir.as_ref() {
+        builder = builder.dir(dir);
     }
-    #[cfg(all(feature = "vulkan", not(feature = "cuda")))]
-    {
-        if args.cpu {
-            run_cpu(args)?;
-        } else {
-            tracing::info!("using vulkan backend");
-            let dev = xn::vulkan_backend::Device::new(0)?;
-            run_for_device::<xn::Unquantized<f32, _>>(args, dev)?;
-        }
+    if let Some(quant) = args.quant.as_deref() {
+        builder = builder.quant(Quant::parse(quant)?);
     }
-    #[cfg(all(feature = "metal", not(any(feature = "cuda", feature = "vulkan"))))]
-    {
-        if args.cpu {
-            run_cpu(args)?;
-        } else {
-            tracing::info!("using metal backend");
-            let dev = xn::metal_backend::Device::new(0)?;
-            run_for_device::<xn::Unquantized<half::bf16, _>>(args, dev)?;
-        }
+    if let Some(cfg_coef) = args.cfg_coef {
+        builder = builder.cfg_coef(cfg_coef);
     }
-    #[cfg(not(any(feature = "cuda", feature = "vulkan", feature = "metal")))]
-    {
-        run_cpu(args)?;
+    // An embedding file can be registered before the model loads; an audio file
+    // has to wait until the speaker codec's sample rate is known.
+    let voice = VoiceArg::parse(args.voice.as_deref());
+    if let VoiceArg::Embedding(path) = &voice {
+        builder = builder.add_voice(VoiceArg::REGISTERED, path.clone());
     }
 
+    tracing::info!("loading model");
+    let mut tts = builder.build()?;
+    tracing::info!(device = %tts.device_name(), voices = ?tts.voices(), "model loaded");
+
+    let mut opts = SpeechOptions::default();
+    match &voice {
+        VoiceArg::Default => {}
+        VoiceArg::Bundled(name) => opts = opts.voice(name.clone()),
+        VoiceArg::Embedding(_) => opts = opts.voice(VoiceArg::REGISTERED),
+        VoiceArg::Audio(path) => {
+            let pcm = load_voice_audio(path, tts.voice_prompt_sample_rate())?;
+            tts.add_voice_from_pcm(VoiceArg::REGISTERED, &pcm)?;
+            opts = opts.voice(VoiceArg::REGISTERED);
+        }
+    }
+
+    // Text normalization is a property of the text, not of the model, so it runs
+    // before anything is handed to `Synth`.
+    let text = match args.lang.as_deref() {
+        None => std::borrow::Cow::Borrowed(args.text.as_str()),
+        Some(lang) => {
+            let lang = ptts::preprocess::Lang::from_str(lang)?;
+            let normalized = ptts::preprocess::normalize_text(&args.text, lang);
+            tracing::info!(?normalized, "normalized input text");
+            std::borrow::Cow::Owned(normalized)
+        }
+    };
+
+    tracing::info!("generating");
+    let start = std::time::Instant::now();
+    let stream = match args.rng_values.as_ref() {
+        None => tts.stream_with(&text, &opts)?,
+        Some(path) => {
+            let values: Vec<f32> = serde_json::from_str(&std::fs::read_to_string(path)?)?;
+            let rng = ptts::flow_lm::ReplayRng::new(values)?;
+            tts.stream_with_rng(&text, &opts, Box::new(rng))?
+        }
+    };
+
+    let sample_rate = stream.sample_rate();
+    let mut pcm = Vec::new();
+    let mut first_chunk_ms = None;
+    for chunk in stream {
+        pcm.extend_from_slice(&chunk?);
+        first_chunk_ms.get_or_insert_with(|| start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    let elapsed = start.elapsed().as_secs_f64();
+    let duration = pcm.len() as f64 / sample_rate as f64;
+    tracing::info!(
+        "generated {duration:.2}s in {elapsed:.2}s (RTF={:.3}, first chunk {:.0}ms)",
+        duration / elapsed,
+        first_chunk_ms.unwrap_or(0.0),
+    );
+    // `getrusage` is unix-only, so this is absent on Windows.
     if let Some(rss_mb) = peak_rss_mb() {
         tracing::info!("peak RSS: {rss_mb:.2} MB");
     }
 
+    ptts::wav::write_wav_file(&args.output, &pcm, sample_rate as u32)?;
+    tracing::info!("wrote {}", args.output.display());
     Ok(())
+}
+
+/// What `--voice` was pointing at.
+enum VoiceArg {
+    /// Not given: use whichever voice the model defaults to.
+    Default,
+    /// A voice id shipped with the checkpoint, e.g. `alba`.
+    Bundled(String),
+    /// A precomputed voice embedding, e.g. from the `create_voice` example.
+    Embedding(std::path::PathBuf),
+    /// An audio file to clone, ~10s of speech.
+    Audio(std::path::PathBuf),
+}
+
+impl VoiceArg {
+    /// Name the two file forms get registered under.
+    const REGISTERED: &'static str = "custom";
+
+    fn parse(arg: Option<&str>) -> Self {
+        match arg {
+            None => Self::Default,
+            Some(arg) if arg.ends_with(".safetensors") => Self::Embedding(arg.into()),
+            Some(arg) if std::path::Path::new(arg).is_file() => Self::Audio(arg.into()),
+            Some(arg) => Self::Bundled(arg.to_string()),
+        }
+    }
+}
+
+/// Decode an audio file to mono PCM at `sample_rate`, for voice cloning.
+fn load_voice_audio(path: &std::path::Path, sample_rate: usize) -> Result<Vec<f32>> {
+    let (pcm, file_rate) = audio_helpers::pcm_decode(path)?;
+    tracing::info!(?path, samples = pcm.len(), rate = file_rate, "decoded voice prompt");
+    if file_rate as usize == sample_rate {
+        Ok(pcm)
+    } else {
+        Ok(audio_helpers::resample(&pcm, file_rate as usize, sample_rate)?)
+    }
+}
+
+fn init_tracing(chrome_tracing: bool) -> Option<tracing_chrome::FlushGuard> {
+    use tracing_subscriber::{EnvFilter, prelude::*};
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let fmt = tracing_subscriber::fmt::Layer::new().with_target(false);
+    if chrome_tracing {
+        let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new().build();
+        tracing_subscriber::registry().with(fmt).with(chrome_layer).with(filter).init();
+        Some(guard)
+    } else {
+        tracing_subscriber::registry().with(fmt).with(filter).init();
+        None
+    }
 }
 
 /// Peak resident set size, or `None` on platforms with no `getrusage`.
@@ -258,350 +240,4 @@ fn peak_rss_mb() -> Option<f64> {
 #[cfg(not(unix))]
 fn peak_rss_mb() -> Option<f64> {
     None
-}
-
-/// Either the library's seeded sampler, or a canned list of values replayed from a file, which
-/// is how a run is made to match a reference trace exactly.
-enum Rng {
-    Normal(Box<NormalRng>),
-    FromFile { values: Vec<f32>, index: usize },
-}
-
-impl Rng {
-    pub fn std_rng(temperature: f32, seed: u64) -> Result<Self> {
-        Ok(Self::Normal(Box::new(NormalRng::new(temperature, seed)?)))
-    }
-
-    pub fn from_file(path: &str) -> Result<Self> {
-        let file = std::fs::read_to_string(path)?;
-        let values = serde_json::from_str::<Vec<f32>>(&file)?;
-        Ok(Self::FromFile { values, index: 0 })
-    }
-}
-
-impl ptts::flow_lm::Rng for Rng {
-    fn sample(&mut self) -> f32 {
-        match self {
-            Self::Normal(rng) => rng.sample(),
-            Self::FromFile { values, index } => {
-                if *index >= values.len() {
-                    *index = 0;
-                }
-                let val = values[*index];
-                *index += 1;
-                val
-            }
-        }
-    }
-}
-
-fn spawn<F, R>(f: F) -> std::thread::JoinHandle<R>
-where
-    F: FnOnce() -> Result<R>,
-    F: Send + 'static,
-    R: Send + 'static,
-{
-    std::thread::spawn(move || match f() {
-        Err(e) => {
-            tracing::error!(?e, "thread error");
-            std::process::exit(1);
-        }
-        Ok(res) => res,
-    })
-}
-
-fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()> {
-    use std::str::FromStr;
-    let (model_path, tokenizer_path, voice, cfg) = match args.config.as_ref() {
-        Some(config) => {
-            let config = std::fs::canonicalize(config)?;
-            let parent = config.parent().context("config path has no parent")?;
-            let model_path = match args.weights.as_ref() {
-                None => parent.join("model.safetensors"),
-                Some(p) => std::path::PathBuf::from_str(p)?,
-            };
-            let tokenizer_path = parent.join("tokenizer.model");
-            tracing::info!(?config, "using local config");
-            let config: ptts::tts_model::TTSConfig =
-                serde_json::from_str(&std::fs::read_to_string(config)?)?;
-            let voice = match args.voice {
-                None => None,
-                Some(voice) if voice.ends_with(".safetensors") => {
-                    let voice_path = std::path::PathBuf::from(voice);
-                    if !voice_path.exists() {
-                        anyhow::bail!("voice embedding file '{}' not found", voice_path.display());
-                    }
-                    Some(Voice::Safetensors(voice_path))
-                }
-                Some(voice) => Some(Voice::Audio(voice)),
-            };
-            (model_path, tokenizer_path, voice, config)
-        }
-        None => {
-            if args.weights.is_some() {
-                anyhow::bail!("--weights option is not supported without --config");
-            }
-            let voice = args.voice.unwrap_or("alba".to_string());
-            if !VOICES.contains(&voice.as_str()) && !std::path::PathBuf::from(&voice).exists() {
-                anyhow::bail!("unknown voice '{voice}'. Available voices: {}", VOICES.join(", "));
-            }
-
-            let (model_path, tokenizer_path, voice) = download_files(&voice)?;
-            (model_path, tokenizer_path, Some(voice), TTSConfig::v202601(args.temperature))
-        }
-    };
-
-    let tokenizer = Tok::open(&tokenizer_path)?;
-    let text = match args.lang.as_deref() {
-        None => std::borrow::Cow::Borrowed(args.text.as_str()),
-        Some(lang) => {
-            let lang = ptts::preprocess::Lang::from_str(lang)?;
-            let normalized = ptts::preprocess::normalize_text(&args.text, lang);
-            tracing::info!(?normalized, "normalized input text");
-            std::borrow::Cow::Owned(normalized)
-        }
-    };
-    let chunks = split_into_best_sentences(&tokenizer, &text, None)?;
-
-    let mut rng = match args.rng_values {
-        Some(path) => Rng::from_file(&path)?,
-        None => Rng::std_rng(args.temperature, args.seed)?,
-    };
-
-    tracing::info!(
-        "avx: {}, neon: {}, simd128: {}, f16c: {}",
-        xn::with_avx(),
-        xn::with_neon(),
-        xn::with_simd128(),
-        xn::with_f16c()
-    );
-
-    let model_ext = cfg.model_ext();
-    tracing::info!(?model_path, ?model_ext, "loading model");
-    let vb = model_helpers::load_weights::<Q>(&model_path, &dev)?;
-    let model: TTSModel<Q> = TTSModel::load(&vb, Box::new(tokenizer), &cfg)?;
-    vb.check_all_used_with_ignore(model_helpers::is_unused_by_tts_model)?;
-    tracing::info!("model loaded successfully!");
-
-    let mut max_seq_budget = 0;
-    let mut all_tokens = vec![];
-    for chunk in chunks.iter() {
-        let (text, frames_after_eos) = prepare_text_prompt(chunk);
-        let tokens = model.flow_lm.conditioner.tokenize(&text)?;
-        let num_tokens = tokens.len();
-        tracing::info!(?text, ?num_tokens, "processing text");
-        let max_frames = max_frames_for(num_tokens);
-        let seq_budget = num_tokens + 512 + max_frames;
-        max_seq_budget = max_seq_budget.max(seq_budget);
-        all_tokens.push((tokens, max_frames, frames_after_eos));
-    }
-    // Init states
-    let mut tts_state = model.init_flow_lm_state(1, max_seq_budget)?;
-    let mut cfg_state = match args.cfg_coef {
-        Some(1.0) | None => None,
-        Some(coef) => {
-            tracing::info!(?coef, "using custom cfg coefficient");
-            let null_state = model.init_flow_lm_state(1, max_seq_budget)?;
-            Some((coef, null_state))
-        }
-    };
-    let mimi_state = model.init_mimi_state(1)?;
-
-    // Load voice embedding
-    if let Some(voice) = voice {
-        let (voice_emb, null_emb) = match voice {
-            Voice::Safetensors(voice_path) => {
-                if cfg_state.is_some() {
-                    anyhow::bail!("cfg is not supported with pre-computed voice embeddings");
-                }
-                let voice_emb =
-                    model_helpers::load_voice_emb(&voice_path, cfg.model_ext().as_deref(), &dev)?
-                        .to::<Q::T>()?;
-                (voice_emb, None)
-            }
-            Voice::Audio(path) => {
-                tracing::info!("loading voice from audio file {}", path);
-                let speaker_sr = cfg.speaker_mimi_cfg().sample_rate;
-                let (mut pcm, sample_rate) = audio_helpers::pcm_decode(&path)?;
-                ptts::utils::normalize_loudness(&mut pcm, sample_rate)?;
-                let sample_rate = sample_rate as usize;
-                let pcm = if sample_rate != speaker_sr {
-                    audio_helpers::resample(&pcm, sample_rate, speaker_sr)?
-                } else {
-                    pcm
-                };
-                tracing::info!("loaded audio with {} samples", pcm.len());
-                let sr = speaker_sr as f32;
-                let min_len = (sr * cfg.audio_prompt_min_duration).round() as usize;
-                let max_len = (sr * cfg.audio_prompt_max_duration).round() as usize;
-                let pcm = if pcm.len() > max_len {
-                    tracing::info!(
-                        max_duration = cfg.audio_prompt_max_duration,
-                        "trimming audio to max duration"
-                    );
-                    pcm[..max_len].to_vec()
-                } else {
-                    pcm
-                };
-                if pcm.len() < min_len {
-                    anyhow::bail!(
-                        "audio prompt is shorter than min duration ({}s, {} samples; got {})",
-                        cfg.audio_prompt_min_duration,
-                        min_len,
-                        pcm.len()
-                    );
-                }
-                let pcm_tensor = Tensor::from_vec(pcm, (1, 1, ()), &dev)?.to::<Q::T>()?;
-                let mimi_enc: MimiEnc<Q> = MimiEnc::load(&vb, &cfg)?;
-                let emb = mimi_enc.encode_audio(&pcm_tensor)?;
-                tracing::info!(?emb, "encoded audio to latent");
-                let null_emb = if cfg_state.is_some() && !cfg.cfg_null_audio_empty {
-                    let null_pcm_tensor = pcm_tensor.zeros_like()?;
-                    Some(mimi_enc.encode_audio(&null_pcm_tensor)?)
-                } else {
-                    None
-                };
-                (emb, null_emb)
-            }
-        };
-        // Prompt with audio conditioning
-        tracing::info!("prompting with voice conditioning ({} frames)...", voice_emb.dim(1usize)?);
-        let start = std::time::Instant::now();
-        model.prompt_audio(&mut tts_state, &voice_emb)?;
-        if let Some((_, ref mut null_state)) = cfg_state
-            && let Some(null_emb) = null_emb.as_ref()
-        {
-            model.prompt_audio(null_state, null_emb)?;
-        }
-        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-        tracing::info!("done prompting with voice conditioning in {elapsed_ms:.2}ms");
-    }
-
-    let start = std::time::Instant::now();
-    tracing::info!("starting generation...");
-    let mut all_audios = vec![];
-    let mut backbone_step_timings_ms = vec![];
-    let model = std::sync::Arc::new(model);
-    for (tokens, max_frames, frames_after_eos) in all_tokens.into_iter() {
-        tracing::info!("prompting with text conditioning ({} tokens)...", tokens.len());
-        let start = std::time::Instant::now();
-        let mut tts_state = tts_state.clone();
-        let mut mimi_state = mimi_state.clone();
-        if let Some(pad_to) = args.pad_to {
-            model.prompt_text_with_padding(&mut tts_state, &tokens, pad_to)?;
-        } else {
-            model.prompt_text(&mut tts_state, &tokens)?;
-        }
-        if let Some((_, ref mut null_state)) = cfg_state {
-            model.prompt_text_null(null_state)?;
-        }
-        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-        tracing::info!("done prompting with text conditioning in {elapsed_ms:.2}ms");
-
-        // BOS marker: NaN tensor [1, 1, ldim]
-        let ldim = cfg.flow_lm.ldim;
-        let nan_data: Vec<f32> = vec![f32::NAN; ldim];
-        let mut prev_latent: Tensor<Q::T, Q::B> =
-            Tensor::from_vec(nan_data, (1, 1, ldim), &dev)?.to::<Q::T>()?;
-
-        let mut eos_countdown: Option<usize> = None;
-
-        let (latent_tx, latent_rx) = std::sync::mpsc::channel::<Tensor<Q::T, _>>();
-        let is_done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let jh = spawn({
-            let wait_to_decode = args.wait_to_decode;
-            let decode_batching = args.decode_batching;
-            let model = model.clone();
-            let is_done = is_done.clone();
-            move || {
-                let mut audio_chunks: Vec<Tensor<f32, Q::B>> = Vec::new();
-                if wait_to_decode {
-                    tracing::info!("waiting for generation to finish before decoding...");
-                    while !is_done.load(std::sync::atomic::Ordering::SeqCst) {
-                        std::thread::sleep(std::time::Duration::from_millis(2));
-                    }
-                }
-                while let Ok(next_latent) = latent_rx.recv() {
-                    // Decode every latent the generator has queued in one streaming call: the
-                    // decoder is exact for any number of frames and one call over several frames
-                    // is much cheaper than one call per frame. Only what is already queued is
-                    // taken, so the first frame never waits.
-                    let mut latents = vec![next_latent];
-                    if decode_batching {
-                        while let Ok(more) = latent_rx.try_recv() {
-                            latents.push(more);
-                        }
-                    }
-                    let refs: Vec<&Tensor<Q::T, _>> = latents.iter().collect();
-                    let batch = Tensor::cat(&refs, 1)?.to()?;
-                    let audio_chunk = model.decode_latent(&batch, &mut mimi_state)?;
-                    audio_chunks.push(audio_chunk);
-                }
-                // Concatenate audio
-                let audio_refs: Vec<&Tensor<f32, Q::B>> = audio_chunks.iter().collect();
-                let audio = Tensor::cat(&audio_refs, 2)?;
-                let audio = audio.narrow(0, ..1)?.contiguous()?;
-                Ok::<_, anyhow::Error>(audio)
-            }
-        });
-
-        for step in 0..max_frames {
-            let step_start = std::time::Instant::now();
-            let (next_latent, is_eos) = match cfg_state.as_mut() {
-                Some((coef, null_state)) => model.generate_step_cfg(
-                    &mut tts_state,
-                    null_state,
-                    *coef,
-                    &prev_latent,
-                    &mut rng,
-                )?,
-                None => model.generate_step(&mut tts_state, &prev_latent, &mut rng)?,
-            };
-            backbone_step_timings_ms.push(step_start.elapsed().as_secs_f64() * 1000.0);
-            latent_tx.send(next_latent.clone())?;
-
-            if is_eos && eos_countdown.is_none() {
-                eos_countdown = Some(frames_after_eos);
-            }
-
-            if let Some(ref mut countdown) = eos_countdown {
-                if *countdown == 0 {
-                    tracing::info!(?step, "reached eos");
-                    break;
-                }
-                *countdown -= 1;
-            }
-
-            prev_latent = next_latent;
-
-            if (step + 1) % 25 == 0 {
-                tracing::info!(?step, ?max_frames, "generation progress");
-            }
-        }
-        std::mem::drop(latent_tx); // Close channel to signal generation thread to finish
-        is_done.store(true, std::sync::atomic::Ordering::SeqCst);
-        let audio = jh.join().map_err(|_| anyhow::anyhow!("cannot join thread"))?;
-        all_audios.push(audio);
-    }
-    let all_audios = all_audios.iter().collect::<Vec<&Tensor<f32, Q::B>>>();
-    let audio = Tensor::cat(&all_audios, 2)?;
-    let pcm = audio.to_vec()?;
-    let duration = pcm.len() as f64 / cfg.mimi.sample_rate as f64;
-
-    let elapsed = start.elapsed().as_secs_f64();
-    let rtf = duration / elapsed;
-    tracing::info!("generated {duration:.2}s in {elapsed:.2}s (RTF={rtf:.3})");
-    let nsteps = backbone_step_timings_ms.len();
-    tracing::info!(
-        ?nsteps,
-        "average backbone step time: {:.2}ms",
-        backbone_step_timings_ms.iter().sum::<f64>() / nsteps as f64
-    );
-
-    // Write WAV
-    let output_file = std::fs::File::create(&args.output)?;
-    let mut writer = std::io::BufWriter::new(output_file);
-    ptts::wav::write_pcm_as_wav(&mut writer, &pcm, cfg.mimi.sample_rate as u32, 1)?;
-    tracing::info!("saving output to {}", args.output.display());
-    Ok(())
 }

--- a/ptts/examples/say.rs
+++ b/ptts/examples/say.rs
@@ -1,0 +1,16 @@
+//! The shortest thing that makes a sound.
+//!
+//! ```text
+//! cargo run --release --example say --features sp,hub -- "hello world"
+//! ```
+
+fn main() -> xn::Result<()> {
+    let text = std::env::args().nth(1).unwrap_or_else(|| "Hello from Pocket TTS.".to_string());
+
+    let tts = ptts::synth::Synth::from_hub()?;
+    let pcm = tts.say(&text)?;
+    ptts::wav::write_wav_file("out.wav", &pcm, tts.sample_rate() as u32)?;
+
+    println!("wrote out.wav ({:.2}s)", pcm.len() as f32 / tts.sample_rate() as f32);
+    Ok(())
+}

--- a/ptts/src/flow_lm.rs
+++ b/ptts/src/flow_lm.rs
@@ -33,6 +33,41 @@ impl Rng for NormalRng {
     }
 }
 
+/// Lets a boxed noise source be passed where an `impl Rng` is expected, so a
+/// caller can choose one at runtime.
+impl Rng for Box<dyn Rng + Send> {
+    fn sample(&mut self) -> f32 {
+        (**self).sample()
+    }
+}
+
+/// Replays a fixed sequence of values, cycling when exhausted.
+///
+/// The sampler's only source of randomness is [`Rng`], so feeding it a recorded
+/// sequence makes a generation reproducible across implementations — which is
+/// how this crate is compared against the reference one step for step.
+pub struct ReplayRng {
+    values: Vec<f32>,
+    index: usize,
+}
+
+impl ReplayRng {
+    pub fn new(values: Vec<f32>) -> Result<Self> {
+        if values.is_empty() {
+            xn::bail!("ReplayRng needs at least one value")
+        }
+        Ok(Self { values, index: 0 })
+    }
+}
+
+impl Rng for ReplayRng {
+    fn sample(&mut self) -> f32 {
+        let value = self.values[self.index % self.values.len()];
+        self.index += 1;
+        value
+    }
+}
+
 /// Lagrangian Self Distillation decode.
 /// Rebuilds the data sample from starting point x_0.
 fn lsd_decode<T: WithDTypeF, B: Backend>(
@@ -279,5 +314,50 @@ impl<Q: BackendQ> FlowLM<Q> {
             }
         }
         Tensor::from_vec(out_data, sequence.shape().clone(), sequence.device())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normal_rng_is_reproducible_from_its_seed() {
+        let mut a = NormalRng::new(0.7, 42).unwrap();
+        let mut b = NormalRng::new(0.7, 42).unwrap();
+        for _ in 0..16 {
+            assert_eq!(a.sample(), b.sample());
+        }
+    }
+
+    #[test]
+    fn normal_rng_differs_between_seeds() {
+        let mut a = NormalRng::new(0.7, 1).unwrap();
+        let mut b = NormalRng::new(0.7, 2).unwrap();
+        let xs: Vec<f32> = (0..8).map(|_| a.sample()).collect();
+        let ys: Vec<f32> = (0..8).map(|_| b.sample()).collect();
+        assert_ne!(xs, ys);
+    }
+
+    #[test]
+    fn zero_temperature_removes_the_noise() {
+        // std = sqrt(0) = 0, so the sampler becomes deterministic rather than erroring.
+        let mut rng = NormalRng::new(0.0, 7).unwrap();
+        for _ in 0..8 {
+            assert_eq!(rng.sample(), 0.0);
+        }
+    }
+
+    #[test]
+    fn replay_rng_cycles_and_rejects_empty() {
+        let mut rng = ReplayRng::new(vec![1.0, 2.0]).unwrap();
+        assert_eq!([rng.sample(), rng.sample(), rng.sample()], [1.0, 2.0, 1.0]);
+        assert!(ReplayRng::new(vec![]).is_err());
+    }
+
+    #[test]
+    fn a_boxed_rng_forwards_to_its_inner_source() {
+        let mut boxed: Box<dyn Rng + Send> = Box::new(ReplayRng::new(vec![3.0, 4.0]).unwrap());
+        assert_eq!([boxed.sample(), boxed.sample()], [3.0, 4.0]);
     }
 }

--- a/ptts/src/lib.rs
+++ b/ptts/src/lib.rs
@@ -1,3 +1,40 @@
+//! Pocket TTS: text to 24 kHz speech, on device.
+//!
+//! Text is tokenized, a flow-matching language model turns the tokens into Mimi
+//! codec latents, and the Mimi decoder turns those into PCM. Generation is
+//! streaming throughout: latents are decoded as they are produced.
+//!
+//! # Getting started
+//!
+//! [`synth::Synth`] is the whole pipeline behind one call:
+//!
+//! ```no_run
+//! # fn main() -> xn::Result<()> {
+//! let tts = ptts::synth::Synth::from_hub()?;
+//! let pcm = tts.say("Hello world")?;
+//! ptts::wav::write_wav_file("out.wav", &pcm, tts.sample_rate() as u32)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Layers
+//!
+//! | Module | Role |
+//! |---|---|
+//! | [`synth`] | The one-call API: load, prime, generate, decode. Start here. |
+//! | [`loader`] | Locating weights, the published-name mapping, voice files. |
+//! | [`plan`] | Frame and KV budgets, the end-of-speech policy. |
+//! | [`preprocess`] | Per-language text normalization, applied before tokenizing. |
+//! | [`tok`] | Tokenizers, behind the `sp` / `hf` features. |
+//! | [`tts_model`] | [`tts_model::TTSModel`], the streaming primitives `synth` drives. |
+//! | [`flow_lm`], [`transformer`] | The token-conditioned flow-matching LM. |
+//! | [`mimi`], [`seanet`] | The neural audio codec. |
+//!
+//! Callers that need to drive generation themselves — a browser build stepping
+//! from an event loop, a server interleaving requests — should use
+//! [`tts_model::TTSModel`] directly. `Synth` is a composition of those
+//! primitives, not a replacement for them.
+
 pub mod conditioners;
 pub mod conv;
 pub mod dummy_quantizer;
@@ -6,10 +43,12 @@ pub mod layer_scale;
 pub mod loader;
 pub mod mimi;
 pub mod mlp;
+pub mod plan;
 pub mod preprocess;
 pub mod resample;
 pub mod rope;
 pub mod seanet;
+pub mod synth;
 #[cfg(any(feature = "sp", feature = "hf"))]
 pub mod tok;
 pub mod transformer;

--- a/ptts/src/loader.rs
+++ b/ptts/src/loader.rs
@@ -97,13 +97,16 @@ pub fn load_voice_emb<B: Backend>(
 /// none is accepted: older voices predate the metadata.
 fn check_model_ext(path: &std::path::Path, model_ext: &str) -> Result<()> {
     let header = read_safetensors_header(path)?;
-    let (_, metadata) =
-        safetensors::SafeTensors::read_metadata(&header).map_err(xn::Error::wrap)?;
-    if let Some(metadata) = metadata.metadata()
-        && let Some(voice_model_ext) = metadata.get("model_ext")
+    // Not `SafeTensors::read_metadata`: it validates that the buffer holds the
+    // tensor data as well as the header, which is exactly what is not read here.
+    let header: serde_json::Value = serde_json::from_slice(&header).map_err(|e| {
+        xn::Error::msg(format!("cannot parse safetensors header of {}: {e}", path.display()))
+    })?;
+    if let Some(voice_model_ext) = header.get("__metadata__").and_then(|m| m.get("model_ext"))
+        && let Some(voice_model_ext) = voice_model_ext.as_str()
     {
         tracing::info!(?voice_model_ext, "voice embedding model_ext from metadata");
-        if voice_model_ext.as_str() != model_ext {
+        if voice_model_ext != model_ext {
             xn::bail!(
                 "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
             )
@@ -112,8 +115,8 @@ fn check_model_ext(path: &std::path::Path, model_ext: &str) -> Result<()> {
     Ok(())
 }
 
-/// Reads just enough of a safetensors file for `read_metadata`: the 8-byte
-/// little-endian header length, then the header itself.
+/// Reads a safetensors file's JSON header: the 8-byte little-endian header
+/// length, then that many bytes.
 ///
 /// `load_voice_emb` is called once per voice while a model loads, and the
 /// published checkpoint ships eight of them, so reading whole files here would
@@ -130,9 +133,8 @@ fn read_safetensors_header(path: &std::path::Path) -> Result<Vec<u8>> {
     if header_len > 100 * 1024 * 1024 {
         xn::bail!("{} does not look like a safetensors file", path.display())
     }
-    let mut buf = len_bytes.to_vec();
-    buf.resize(8 + header_len as usize, 0);
-    file.read_exact(&mut buf[8..])?;
+    let mut buf = vec![0u8; header_len as usize];
+    file.read_exact(&mut buf)?;
     Ok(buf)
 }
 
@@ -184,6 +186,32 @@ mod tests {
             remap_key("flow_lm.flow.layers.0.weight").as_deref(),
             Some("flow_lm.flow_net.layers.0.weight")
         );
+    }
+
+    #[test]
+    fn model_ext_is_read_from_a_header_only_read() {
+        // One f32 of tensor data, so the header alone is not the whole file:
+        // `check_model_ext` must not need the data section to parse the header.
+        let write = |name: &str, header: &str| {
+            let path = std::env::temp_dir().join(name);
+            let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+            bytes.extend_from_slice(header.as_bytes());
+            bytes.extend_from_slice(&0f32.to_le_bytes());
+            std::fs::write(&path, &bytes).unwrap();
+            path
+        };
+        let tensor = r#""emb":{"dtype":"F32","shape":[1,1,1],"data_offsets":[0,4]}"#;
+
+        let matching = write(
+            "ptts-loader-voice-match.safetensors",
+            &format!(r#"{{"__metadata__":{{"model_ext":"abc@1"}},{tensor}}}"#),
+        );
+        check_model_ext(&matching, "abc@1").unwrap();
+        assert!(check_model_ext(&matching, "def@2").is_err());
+
+        // A voice from before the metadata existed is accepted as-is.
+        let bare = write("ptts-loader-voice-bare.safetensors", &format!(r#"{{{tensor}}}"#));
+        check_model_ext(&bare, "abc@1").unwrap();
     }
 
     #[test]

--- a/ptts/src/loader.rs
+++ b/ptts/src/loader.rs
@@ -4,6 +4,7 @@
 //! rename the same checkpoint keys, skip the same unused tensors and unpack voice files the same
 //! way. Keeping that here means a checkpoint layout change is one edit rather than four.
 
+use crate::tts_model::TTSConfig;
 use xn::nn::{Path, VB};
 use xn::{Backend, BackendQ, Result, Tensor};
 
@@ -95,9 +96,9 @@ pub fn load_voice_emb<B: Backend>(
 /// Fails if the voice file records a `model_ext` other than `model_ext`. A file that records
 /// none is accepted: older voices predate the metadata.
 fn check_model_ext(path: &std::path::Path, model_ext: &str) -> Result<()> {
-    let file_content = std::fs::read(path)?;
+    let header = read_safetensors_header(path)?;
     let (_, metadata) =
-        safetensors::SafeTensors::read_metadata(&file_content).map_err(xn::Error::wrap)?;
+        safetensors::SafeTensors::read_metadata(&header).map_err(xn::Error::wrap)?;
     if let Some(metadata) = metadata.metadata()
         && let Some(voice_model_ext) = metadata.get("model_ext")
     {
@@ -109,6 +110,30 @@ fn check_model_ext(path: &std::path::Path, model_ext: &str) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Reads just enough of a safetensors file for `read_metadata`: the 8-byte
+/// little-endian header length, then the header itself.
+///
+/// `load_voice_emb` is called once per voice while a model loads, and the
+/// published checkpoint ships eight of them, so reading whole files here would
+/// double the bytes touched at startup for no reason.
+fn read_safetensors_header(path: &std::path::Path) -> Result<Vec<u8>> {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path)?;
+    let mut len_bytes = [0u8; 8];
+    file.read_exact(&mut len_bytes)?;
+    let header_len = u64::from_le_bytes(len_bytes);
+    // A file that is not safetensors can claim an absurd header length; refuse
+    // to allocate on its word.
+    if header_len > 100 * 1024 * 1024 {
+        xn::bail!("{} does not look like a safetensors file", path.display())
+    }
+    let mut buf = len_bytes.to_vec();
+    buf.resize(8 + header_len as usize, 0);
+    file.read_exact(&mut buf[8..])?;
+    Ok(buf)
 }
 
 #[cfg(test)]
@@ -176,5 +201,239 @@ mod tests {
         }
         assert!(!is_unused_by_tts_model("flow_lm.transformer.layers.0.linear1.weight"));
         assert!(!is_unused_by_tts_model("mimi.decoder.layers.0.weight"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Where a checkpoint comes from
+// ---------------------------------------------------------------------------
+
+/// Voice embeddings shipped with the published checkpoint.
+pub const VOICES: &[&str] =
+    &["alba", "marius", "javert", "jean", "fantine", "cosette", "eponine", "azelma"];
+
+/// Default Hugging Face repo for the published weights.
+pub const DEFAULT_REPO_ID: &str = "kyutai/pocket-tts";
+
+/// Weight file names tried, in order, when the source does not name one.
+pub const WEIGHT_CANDIDATES: &[&str] =
+    &["model.safetensors", "model.q8.gguf", "tts_b6369a24.safetensors"];
+
+/// Tokenizer file names tried, in order. `tokenizer.json` is the Hugging Face
+/// `tokenizers` format, `tokenizer.model` is SentencePiece; [`crate::tok::Tok`]
+/// picks the reader by extension.
+pub const TOKENIZER_CANDIDATES: &[&str] = &["tokenizer.json", "tokenizer.model"];
+
+/// Where to load a checkpoint from.
+///
+/// [`load_weights`] and [`load_voice_emb`] read files that someone has already
+/// located; this decides *which* files, across the three layouts in use — the
+/// published Hub repo, a local model directory, and explicit paths.
+#[derive(Clone, Debug)]
+pub enum ModelSource {
+    /// A Hugging Face model repo. Requires the `hub` feature.
+    Hub { repo_id: String, weights: Option<String> },
+    /// A local directory holding `config.json`, a weights file, a tokenizer and
+    /// an optional `voices/` or `embeddings/` subdirectory.
+    Dir(std::path::PathBuf),
+    /// Explicit file paths. `config` defaults to [`TTSConfig::v202601`] when absent.
+    Files {
+        config: Option<std::path::PathBuf>,
+        weights: std::path::PathBuf,
+        tokenizer: Option<std::path::PathBuf>,
+    },
+}
+
+impl ModelSource {
+    /// The published checkpoint on the Hugging Face Hub.
+    pub fn hub() -> Self {
+        Self::Hub { repo_id: DEFAULT_REPO_ID.to_string(), weights: None }
+    }
+
+    /// A specific Hugging Face repo, with the default weight-file search order.
+    pub fn hub_repo(repo_id: impl Into<String>) -> Self {
+        Self::Hub { repo_id: repo_id.into(), weights: None }
+    }
+
+    /// Locate every file this source provides, downloading if needed, and parse
+    /// the config.
+    pub fn resolve(&self, temperature: f32) -> Result<Artifacts> {
+        match self {
+            Self::Hub { repo_id, weights } => resolve_hub(repo_id, weights.as_deref(), temperature),
+            Self::Dir(dir) => resolve_dir(dir, temperature),
+            Self::Files { config, weights, tokenizer } => {
+                let config = match config {
+                    Some(path) => read_config(path, temperature)?,
+                    None => TTSConfig::v202601(temperature),
+                };
+                if !weights.is_file() {
+                    xn::bail!("weights file not found: {}", weights.display())
+                }
+                Ok(Artifacts {
+                    config,
+                    weights: weights.clone(),
+                    tokenizer: tokenizer.clone(),
+                    voices: vec![],
+                })
+            }
+        }
+    }
+}
+
+/// A checkpoint's files, located and its config parsed, ready to load.
+#[derive(Clone, Debug)]
+pub struct Artifacts {
+    pub config: TTSConfig,
+    pub weights: std::path::PathBuf,
+    /// `None` when the source carries no tokenizer file; the caller must then
+    /// supply a tokenizer itself.
+    pub tokenizer: Option<std::path::PathBuf>,
+    /// Voice name to embedding file, sorted by name.
+    pub voices: Vec<(String, std::path::PathBuf)>,
+}
+
+fn read_config(path: &std::path::Path, temperature: f32) -> Result<TTSConfig> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| xn::Error::msg(format!("cannot read config {}: {e}", path.display())))?;
+    let mut cfg: TTSConfig = serde_json::from_str(&text)
+        .map_err(|e| xn::Error::msg(format!("cannot parse config {}: {e}", path.display())))?;
+    cfg.temp = temperature;
+    Ok(cfg)
+}
+
+fn resolve_dir(dir: &std::path::Path, temperature: f32) -> Result<Artifacts> {
+    if !dir.is_dir() {
+        xn::bail!("not a directory: {}", dir.display())
+    }
+    let config_path = dir.join("config.json");
+    let config = if config_path.is_file() {
+        read_config(&config_path, temperature)?
+    } else {
+        TTSConfig::v202601(temperature)
+    };
+
+    let weights = WEIGHT_CANDIDATES
+        .iter()
+        .map(|name| dir.join(name))
+        .find(|path| path.is_file())
+        .ok_or_else(|| {
+        xn::Error::msg(format!(
+            "no weights file in {}; expected one of {}",
+            dir.display(),
+            WEIGHT_CANDIDATES.join(", ")
+        ))
+    })?;
+
+    let tokenizer =
+        TOKENIZER_CANDIDATES.iter().map(|name| dir.join(name)).find(|path| path.is_file());
+
+    let mut voices = vec![];
+    for sub in ["voices", "embeddings"] {
+        collect_voice_dir(&dir.join(sub), &mut voices);
+    }
+    let default_voice = dir.join("default-voice.safetensors");
+    if default_voice.is_file() {
+        voices.push(("default".to_string(), default_voice));
+    }
+    voices.sort();
+    voices.dedup_by(|a, b| a.0 == b.0);
+
+    Ok(Artifacts { config, weights, tokenizer, voices })
+}
+
+/// Adds every `*.safetensors` file in `dir` to `voices`, keyed by file stem. A
+/// missing or unreadable directory is not an error: voices are optional.
+fn collect_voice_dir(dir: &std::path::Path, voices: &mut Vec<(String, std::path::PathBuf)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("safetensors") {
+            continue;
+        }
+        if let Some(name) = path.file_stem().and_then(|s| s.to_str()) {
+            voices.push((name.to_string(), path));
+        }
+    }
+}
+
+#[cfg(not(feature = "hub"))]
+fn resolve_hub(_: &str, _: Option<&str>, _: f32) -> Result<Artifacts> {
+    xn::bail!(
+        "loading from the Hugging Face Hub requires the `hub` feature of the `ptts` crate; \
+         use ModelSource::Dir or ModelSource::Files to load local files instead"
+    )
+}
+
+#[cfg(feature = "hub")]
+fn resolve_hub(repo_id: &str, weights: Option<&str>, temperature: f32) -> Result<Artifacts> {
+    let repo = HubRepo::open(repo_id)?;
+
+    let config = match repo.get_optional("config.json") {
+        Some(path) => read_config(&path, temperature)?,
+        None => TTSConfig::v202601(temperature),
+    };
+
+    let weights = match weights {
+        Some(name) => repo.get(name)?,
+        None => match WEIGHT_CANDIDATES.iter().find_map(|name| repo.get_optional(name)) {
+            Some(path) => path,
+            None => xn::bail!(
+                "no weights file in `{repo_id}`; expected one of {}",
+                WEIGHT_CANDIDATES.join(", ")
+            ),
+        },
+    };
+
+    let tokenizer = TOKENIZER_CANDIDATES.iter().find_map(|name| repo.get_optional(name));
+
+    let mut voices = vec![];
+    for voice in VOICES {
+        if let Some(path) = repo.get_optional(&format!("embeddings/{voice}.safetensors")) {
+            voices.push((voice.to_string(), path));
+        }
+    }
+    if let Some(path) = repo.get_optional("default-voice.safetensors") {
+        voices.push(("default".to_string(), path));
+    }
+    voices.sort();
+
+    Ok(Artifacts { config, weights, tokenizer, voices })
+}
+
+/// A Hugging Face model repo, wrapped so a download failure names the repo, the
+/// file and the URL — `hf_hub`'s own errors mention none of the three, which
+/// makes a gated repo or a renamed file hard to diagnose.
+#[cfg(feature = "hub")]
+struct HubRepo {
+    repo: hf_hub::api::sync::ApiRepo,
+    repo_id: String,
+}
+
+#[cfg(feature = "hub")]
+impl HubRepo {
+    fn open(repo_id: &str) -> Result<Self> {
+        use hf_hub::{Repo, RepoType, api::sync::Api};
+        let api = Api::new()
+            .map_err(|e| xn::Error::msg(format!("cannot reach the Hugging Face Hub: {e}")))?;
+        let repo = api.repo(Repo::new(repo_id.to_string(), RepoType::Model));
+        Ok(Self { repo, repo_id: repo_id.to_string() })
+    }
+
+    fn get(&self, filename: &str) -> Result<std::path::PathBuf> {
+        self.repo.get(filename).map_err(|e| {
+            let url = self.repo.url(filename);
+            xn::Error::msg(format!(
+                "failed to fetch `{filename}` from `{}` ({url}): {e}\n\
+                 If the repo is gated, accept its terms on huggingface.co and run \
+                 `huggingface-cli login` (or set HF_TOKEN).",
+                self.repo_id
+            ))
+        })
+    }
+
+    /// Like [`Self::get`] but maps any failure to `None`, for files that may
+    /// legitimately be absent from a given repo layout.
+    fn get_optional(&self, filename: &str) -> Option<std::path::PathBuf> {
+        self.repo.get(filename).ok()
     }
 }

--- a/ptts/src/plan.rs
+++ b/ptts/src/plan.rs
@@ -1,0 +1,169 @@
+//! Generation policy: how many frames to run, how much KV budget to reserve, and
+//! when to stop.
+//!
+//! These rules were previously inlined — as literals — in every frontend: the
+//! `pocket_tts` example, `ptts-pyo3` (twice), `ptts-wasm` and `ptts-ws-server`
+//! each carried their own copy of `((n / 3.0 + 2.0) * 12.5).ceil()` and their own
+//! EOS countdown loop. They are pure functions of the token count and the config,
+//! so they live here and are unit tested.
+
+/// Extra KV-cache entries reserved on top of the text tokens and the generated
+/// frames, covering the voice-prompt frames (~125 at 12.5Hz for a 10s prompt)
+/// plus slack.
+pub const PROMPT_SEQ_HEADROOM: usize = 512;
+
+/// Frames of audio to generate for a text prompt of `num_tokens` tokens.
+///
+/// Roughly three tokens per second of speech, plus two seconds of slack,
+/// converted to frames at the codec frame rate. This is an upper bound: normal
+/// generation stops earlier, when the model signals EOS (see [`EosPolicy`]).
+///
+/// `frame_rate` comes from `TTSConfig::mimi.frame_rate`. The frontends all
+/// hardcoded `12.5`, which silently assumed the shipped config.
+pub fn frame_budget(num_tokens: usize, frame_rate: f64) -> usize {
+    ((num_tokens as f64 / 3.0 + 2.0) * frame_rate).ceil() as usize
+}
+
+/// KV-cache length to allocate for a single text chunk: its text tokens, the
+/// frames it may generate, and [`PROMPT_SEQ_HEADROOM`] for the voice prompt.
+///
+/// A state is allocated once and reused across chunks, so callers with several
+/// chunks should allocate the max over all of them.
+pub fn seq_budget(num_tokens: usize, frame_budget: usize) -> usize {
+    num_tokens + PROMPT_SEQ_HEADROOM + frame_budget
+}
+
+/// Tracks the tail of a generation: once the model reports EOS, a few more
+/// frames are still emitted so the codec can close out the utterance cleanly.
+///
+/// `frames_after_eos` comes from [`crate::tts_model::prepare_text_prompt`] — 3
+/// for very short prompts, 1 otherwise.
+#[derive(Clone, Copy, Debug)]
+pub struct EosPolicy {
+    frames_after_eos: usize,
+    countdown: Option<usize>,
+}
+
+impl EosPolicy {
+    pub fn new(frames_after_eos: usize) -> Self {
+        Self { frames_after_eos, countdown: None }
+    }
+
+    /// Records the EOS flag of the frame that was just generated and returns
+    /// whether generation should stop now.
+    ///
+    /// Call this once per frame, *after* the frame has been handed to the
+    /// decoder — the EOS frame itself is part of the output.
+    pub fn should_stop(&mut self, is_eos: bool) -> bool {
+        if is_eos && self.countdown.is_none() {
+            self.countdown = Some(self.frames_after_eos);
+        }
+        match self.countdown.as_mut() {
+            None => false,
+            Some(0) => true,
+            Some(countdown) => {
+                *countdown -= 1;
+                false
+            }
+        }
+    }
+
+    /// True once the model has signalled EOS, whether or not the tail has run out.
+    pub fn saw_eos(&self) -> bool {
+        self.countdown.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_budget_matches_the_frontends() {
+        // The literal every frontend carried: ((n / 3 + 2) * 12.5).ceil().
+        for n in [0usize, 1, 7, 12, 50, 137] {
+            let expected = ((n as f64 / 3.0 + 2.0) * 12.5).ceil() as usize;
+            assert_eq!(frame_budget(n, 12.5), expected, "n = {n}");
+        }
+        assert_eq!(frame_budget(0, 12.5), 25);
+        assert_eq!(frame_budget(50, 12.5), 234);
+    }
+
+    #[test]
+    fn frame_budget_follows_the_frame_rate() {
+        assert_eq!(frame_budget(30, 12.5), frame_budget(30, 25.0) / 2);
+    }
+
+    #[test]
+    fn seq_budget_covers_tokens_frames_and_headroom() {
+        assert_eq!(seq_budget(40, 234), 40 + 512 + 234);
+    }
+
+    /// Reference implementation, transcribed from `pocket_tts.rs` before the
+    /// refactor. `EosPolicy` must agree with it frame for frame.
+    fn reference(eos_at: Option<usize>, frames_after_eos: usize, max_frames: usize) -> usize {
+        let mut eos_countdown: Option<usize> = None;
+        let mut emitted = 0;
+        for step in 0..max_frames {
+            emitted += 1;
+            let is_eos = eos_at == Some(step);
+            if is_eos && eos_countdown.is_none() {
+                eos_countdown = Some(frames_after_eos);
+            }
+            if let Some(ref mut countdown) = eos_countdown {
+                if *countdown == 0 {
+                    break;
+                }
+                *countdown -= 1;
+            }
+        }
+        emitted
+    }
+
+    fn under_test(eos_at: Option<usize>, frames_after_eos: usize, max_frames: usize) -> usize {
+        let mut policy = EosPolicy::new(frames_after_eos);
+        let mut emitted = 0;
+        for step in 0..max_frames {
+            emitted += 1;
+            if policy.should_stop(eos_at == Some(step)) {
+                break;
+            }
+        }
+        emitted
+    }
+
+    #[test]
+    fn eos_policy_matches_the_reference_loop() {
+        for frames_after_eos in [0usize, 1, 3] {
+            for eos_at in [None, Some(0), Some(1), Some(5), Some(19)] {
+                for max_frames in [1usize, 6, 20] {
+                    assert_eq!(
+                        under_test(eos_at, frames_after_eos, max_frames),
+                        reference(eos_at, frames_after_eos, max_frames),
+                        "frames_after_eos = {frames_after_eos}, eos_at = {eos_at:?}, max = {max_frames}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn eos_policy_emits_the_eos_frame_plus_the_tail() {
+        // EOS on frame 5 with a 1-frame tail: frames 0..=6 are emitted.
+        assert_eq!(under_test(Some(5), 1, 100), 7);
+        // A 3-frame tail emits three more.
+        assert_eq!(under_test(Some(5), 3, 100), 9);
+        // No EOS: capped by max_frames.
+        assert_eq!(under_test(None, 1, 100), 100);
+    }
+
+    #[test]
+    fn eos_policy_reports_eos() {
+        let mut policy = EosPolicy::new(1);
+        assert!(!policy.saw_eos());
+        policy.should_stop(false);
+        assert!(!policy.saw_eos());
+        policy.should_stop(true);
+        assert!(policy.saw_eos());
+    }
+}

--- a/ptts/src/synth.rs
+++ b/ptts/src/synth.rs
@@ -1,0 +1,1091 @@
+//! One-call speech synthesis.
+//!
+//! [`Synth`] wraps everything between "I have some text" and "I have PCM":
+//! locating and loading a checkpoint, choosing a device and weight format,
+//! registering voices, splitting text into sentence chunks, priming the
+//! transformer state, running the flow-matching solver, and streaming the
+//! latents through the Mimi decoder on a second thread.
+//!
+//! ```no_run
+//! # fn main() -> xn::Result<()> {
+//! use ptts::synth::Synth;
+//!
+//! let tts = Synth::from_hub()?;
+//! let pcm = tts.say("Hello world")?;
+//! ptts::wav::write_wav_file("out.wav", &pcm, tts.sample_rate() as u32)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Audio arrives incrementally from [`Synth::stream`], which is the primitive
+//! [`Synth::say`] is built on:
+//!
+//! ```no_run
+//! # fn main() -> xn::Result<()> {
+//! # let tts = ptts::synth::Synth::from_hub()?;
+//! for chunk in tts.stream("Hello world")? {
+//!     let pcm: Vec<f32> = chunk?;
+//!     // hand `pcm` to an audio sink
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Callers that want to name the weight format at compile time — `ptts-wasm`
+//! supports exactly two — can use [`SynthOf<Q>`] directly and skip the runtime
+//! dispatch in [`Synth`].
+
+use crate::flow_lm::NormalRng;
+use crate::loader::{self, Artifacts, ModelSource};
+use crate::plan::{self, EosPolicy};
+use crate::tts_model::{
+    MAX_TOKENS_PER_CHUNK, MimiEnc, TTSConfig, TTSModel, TTSState, prepare_text_prompt,
+    split_into_best_sentences,
+};
+use std::collections::BTreeMap;
+use std::path::{Path as FsPath, PathBuf};
+use std::sync::Arc;
+use xn::{Backend, BackendQ, Result, Tensor};
+
+/// Which device to run on.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DeviceKind {
+    /// The most capable compiled-in backend: CUDA, then Vulkan, then Metal,
+    /// then the CPU.
+    #[default]
+    Auto,
+    Cpu,
+    Cuda,
+    Vulkan,
+    Metal,
+}
+
+impl DeviceKind {
+    pub fn parse(name: &str) -> Result<Self> {
+        match name {
+            "auto" => Ok(Self::Auto),
+            "cpu" => Ok(Self::Cpu),
+            "cuda" => Ok(Self::Cuda),
+            "vulkan" => Ok(Self::Vulkan),
+            "metal" => Ok(Self::Metal),
+            other => {
+                xn::bail!("unknown device '{other}'; expected auto, cpu, cuda, vulkan or metal")
+            }
+        }
+    }
+
+    /// Resolve [`Self::Auto`] against the backends this build was compiled with.
+    pub fn resolve(self) -> Self {
+        if self != Self::Auto {
+            return self;
+        }
+        if cfg!(feature = "cuda") {
+            Self::Cuda
+        } else if cfg!(feature = "vulkan") {
+            Self::Vulkan
+        } else if cfg!(feature = "metal") {
+            Self::Metal
+        } else {
+            Self::Cpu
+        }
+    }
+}
+
+/// Weight format for the flow-LM transformer linears. Quantization is CPU-only.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Quant {
+    #[default]
+    F32,
+    Q80,
+    Q81,
+    Q8k,
+    Q6k,
+    Q50,
+    Q51,
+    Q5k,
+    Q40,
+    Q41,
+    Q4k,
+}
+
+impl Quant {
+    /// Parse the spellings the CLIs accept.
+    pub fn parse(name: &str) -> Result<Self> {
+        match name {
+            "f32" | "none" => Ok(Self::F32),
+            "q8" | "q8_0" => Ok(Self::Q80),
+            "q8_1" => Ok(Self::Q81),
+            "q8k" => Ok(Self::Q8k),
+            "q6k" => Ok(Self::Q6k),
+            "q5" | "q5_0" => Ok(Self::Q50),
+            "q5_1" => Ok(Self::Q51),
+            "q5k" => Ok(Self::Q5k),
+            "q4" | "q4_0" => Ok(Self::Q40),
+            "q4_1" => Ok(Self::Q41),
+            "q4k" => Ok(Self::Q4k),
+            other => xn::bail!(
+                "unsupported quantization '{other}'; expected one of \
+                 f32, q8_0, q8_1, q8k, q6k, q5_0, q5_1, q5k, q4_0, q4_1, q4k"
+            ),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::F32 => "f32",
+            Self::Q80 => "q8_0",
+            Self::Q81 => "q8_1",
+            Self::Q8k => "q8k",
+            Self::Q6k => "q6k",
+            Self::Q50 => "q5_0",
+            Self::Q51 => "q5_1",
+            Self::Q5k => "q5k",
+            Self::Q40 => "q4_0",
+            Self::Q41 => "q4_1",
+            Self::Q4k => "q4k",
+        }
+    }
+}
+
+/// Per-request overrides. Anything left `None` falls back to what the
+/// [`SynthBuilder`] was configured with.
+#[derive(Clone, Debug, Default)]
+pub struct SpeechOptions {
+    pub voice: Option<String>,
+    pub temperature: Option<f32>,
+    pub seed: Option<u64>,
+    /// Classifier-free guidance coefficient. `1.0` and `None` both disable it.
+    pub cfg_coef: Option<f32>,
+    pub max_tokens_per_chunk: Option<usize>,
+}
+
+impl SpeechOptions {
+    pub fn voice(mut self, voice: impl Into<String>) -> Self {
+        self.voice = Some(voice.into());
+        self
+    }
+
+    pub fn temperature(mut self, temperature: f32) -> Self {
+        self.temperature = Some(temperature);
+        self
+    }
+
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
+    pub fn cfg_coef(mut self, cfg_coef: f32) -> Self {
+        self.cfg_coef = Some(cfg_coef);
+        self
+    }
+
+    pub fn max_tokens_per_chunk(mut self, max_tokens: usize) -> Self {
+        self.max_tokens_per_chunk = Some(max_tokens);
+        self
+    }
+}
+
+/// Defaults applied to every request unless overridden per call.
+#[derive(Clone, Debug)]
+struct Defaults {
+    voice: Option<String>,
+    temperature: f32,
+    seed: u64,
+    cfg_coef: Option<f32>,
+    max_tokens_per_chunk: usize,
+}
+
+/// A registered voice: the conditioning embedding, plus the encoding of
+/// equal-length silence when the model needs one for CFG.
+struct Voice<Q: BackendQ> {
+    emb: Tensor<Q::T, Q::B>,
+    null_emb: Option<Tensor<Q::T, Q::B>>,
+}
+
+/// A loaded model, with the weight format fixed at compile time.
+///
+/// Most callers want [`Synth`], which erases `Q` so the format can be chosen at
+/// runtime.
+pub struct SynthOf<Q: BackendQ> {
+    model: Arc<TTSModel<Q>>,
+    mimi_enc: Option<MimiEnc<Q>>,
+    cfg: TTSConfig,
+    voices: BTreeMap<String, Voice<Q>>,
+    defaults: Defaults,
+}
+
+impl<Q: BackendQ> SynthOf<Q> {
+    pub fn sample_rate(&self) -> usize {
+        self.model.sample_rate()
+    }
+
+    pub fn config(&self) -> &TTSConfig {
+        &self.cfg
+    }
+
+    pub fn device_name(&self) -> String {
+        self.model.device().name()
+    }
+
+    /// Registered voice names, sorted.
+    pub fn voices(&self) -> Vec<String> {
+        self.voices.keys().cloned().collect()
+    }
+
+    /// True if this checkpoint carries a speaker encoder, which voice cloning
+    /// from raw audio requires.
+    pub fn supports_voice_cloning(&self) -> bool {
+        self.mimi_enc.is_some()
+    }
+
+    /// The sample rate [`Self::add_voice_from_pcm`] expects.
+    pub fn voice_prompt_sample_rate(&self) -> usize {
+        self.cfg.speaker_mimi_cfg().sample_rate
+    }
+
+    /// Register a precomputed voice embedding, replacing any voice of the same name.
+    pub fn add_voice_file(&mut self, name: &str, path: &FsPath) -> Result<()> {
+        let dev = self.model.device().clone();
+        let model_ext = self.cfg.model_ext();
+        let emb = loader::load_voice_emb(path, model_ext.as_deref(), &dev)?.to::<Q::T>()?;
+        self.voices.insert(name.to_string(), Voice { emb, null_emb: None });
+        Ok(())
+    }
+
+    /// Clone a voice from a mono audio prompt.
+    ///
+    /// `pcm` must be at [`Self::voice_prompt_sample_rate`] and last between
+    /// `audio_prompt_min_duration` and `audio_prompt_max_duration` seconds:
+    /// longer input is trimmed, shorter input is an error. The caller's slice is
+    /// not modified — loudness normalization runs on an internal copy.
+    pub fn add_voice_from_pcm(&mut self, name: &str, pcm: &[f32]) -> Result<()> {
+        let enc = match self.mimi_enc.as_ref() {
+            Some(enc) => enc,
+            None => xn::bail!("this checkpoint has no speaker encoder, so it cannot clone voices"),
+        };
+        let sr = self.voice_prompt_sample_rate();
+        let min_len = (sr as f32 * self.cfg.audio_prompt_min_duration).round() as usize;
+        let max_len = (sr as f32 * self.cfg.audio_prompt_max_duration).round() as usize;
+        if pcm.len() < min_len {
+            xn::bail!(
+                "voice prompt is too short: got {} samples ({:.2}s at {sr}Hz), need at least \
+                 {min_len} ({:.2}s)",
+                pcm.len(),
+                pcm.len() as f32 / sr as f32,
+                self.cfg.audio_prompt_min_duration
+            );
+        }
+        let mut pcm = pcm[..pcm.len().min(max_len)].to_vec();
+        crate::utils::normalize_loudness(&mut pcm, sr as u32)?;
+
+        let dev = self.model.device().clone();
+        let pcm = Tensor::from_vec(pcm, (1, 1, ()), &dev)?.to::<Q::T>()?;
+        let emb = enc.encode_audio(&pcm)?;
+        // Only needed for CFG, and only when the model conditions its null
+        // branch on silence rather than on nothing at all.
+        let null_emb = if self.cfg.cfg_null_audio_empty {
+            None
+        } else {
+            Some(enc.encode_audio(&pcm.zeros_like()?)?)
+        };
+        self.voices.insert(name.to_string(), Voice { emb, null_emb });
+        Ok(())
+    }
+
+    /// Synthesize `text` and return the whole waveform.
+    pub fn say(&self, text: &str) -> Result<Vec<f32>> {
+        self.say_with(text, &SpeechOptions::default())
+    }
+
+    /// Synthesize `text` with per-request overrides.
+    pub fn say_with(&self, text: &str, opts: &SpeechOptions) -> Result<Vec<f32>> {
+        let mut pcm = Vec::new();
+        for chunk in self.stream_with(text, opts)? {
+            pcm.extend_from_slice(&chunk?);
+        }
+        Ok(pcm)
+    }
+
+    /// Start generating `text`, yielding PCM as the decoder produces it.
+    pub fn stream(&self, text: &str) -> Result<SpeechStream> {
+        self.stream_with(text, &SpeechOptions::default())
+    }
+
+    /// Start generating `text` with per-request overrides.
+    ///
+    /// Generation runs on two background threads — one for the flow-LM, one for
+    /// the Mimi decoder — so decoding overlaps the next backbone step. Dropping
+    /// the returned [`SpeechStream`] stops both.
+    pub fn stream_with(&self, text: &str, opts: &SpeechOptions) -> Result<SpeechStream> {
+        let temperature = opts.temperature.unwrap_or(self.defaults.temperature);
+        let seed = opts.seed.unwrap_or(self.defaults.seed);
+        let rng = Box::new(NormalRng::new(temperature, seed)?);
+        self.stream_with_rng(text, opts, rng)
+    }
+
+    /// As [`Self::stream_with`], but with an explicit noise source.
+    ///
+    /// The solver's only source of randomness is this trait, so replaying a
+    /// fixed sequence (see [`crate::flow_lm::ReplayRng`]) makes a generation
+    /// reproducible across implementations — which is how this crate is
+    /// compared against the reference one. `temperature` and `seed` are ignored.
+    pub fn stream_with_rng(
+        &self,
+        text: &str,
+        opts: &SpeechOptions,
+        rng: Box<dyn crate::flow_lm::Rng + Send>,
+    ) -> Result<SpeechStream> {
+        let max_tokens_per_chunk =
+            opts.max_tokens_per_chunk.unwrap_or(self.defaults.max_tokens_per_chunk);
+        let cfg_coef = match opts.cfg_coef.or(self.defaults.cfg_coef) {
+            Some(coef) if coef != 1.0 => Some(coef),
+            _ => None,
+        };
+
+        let chunks = self.plan_chunks(text, max_tokens_per_chunk)?;
+        let seq_budget = chunks.iter().map(|c| c.seq_budget).max().unwrap_or(0);
+
+        let voice_name = opts.voice.as_ref().or(self.defaults.voice.as_ref());
+        let (base_state, cfg_base) = self.primed_state(voice_name, seq_budget, cfg_coef)?;
+
+        let mimi_init = self.model.init_mimi_state(1)?;
+        let ldim = self.model.flow_lm.ldim;
+
+        let (pcm_tx, pcm_rx) = std::sync::mpsc::channel::<Result<Vec<f32>>>();
+        let (latent_tx, latent_rx) = std::sync::mpsc::channel::<Frame<Q>>();
+
+        // Decoder: latents in, PCM out. Reset between chunks so each chunk
+        // starts from a clean codec state, matching the pre-refactor behavior.
+        let decode_model = Arc::clone(&self.model);
+        let decode_tx = pcm_tx.clone();
+        let decode_handle = std::thread::spawn(move || {
+            let mut state = mimi_init.clone();
+            while let Ok(frame) = latent_rx.recv() {
+                let first = match frame {
+                    Frame::ChunkEnd => {
+                        state = mimi_init.clone();
+                        continue;
+                    }
+                    Frame::Latent(latent) => latent,
+                };
+                // Decode every latent the flow-LM has already queued in one
+                // call: the decoder is exact for any number of frames, and one
+                // call over several is much cheaper than one call per frame.
+                // Only what is already waiting is taken, so no frame is ever
+                // held back for a batch to fill — the first one included.
+                let mut reset_after = false;
+                let mut batch = vec![first];
+                while let Ok(frame) = latent_rx.try_recv() {
+                    match frame {
+                        // Past a chunk boundary the codec state resets, so the
+                        // batch has to stop here and resume on the next frame.
+                        Frame::ChunkEnd => {
+                            reset_after = true;
+                            break;
+                        }
+                        Frame::Latent(latent) => batch.push(latent),
+                    }
+                }
+                let latent = match batch.len() {
+                    1 => batch.pop().expect("just checked"),
+                    _ => match Tensor::cat(&batch.iter().collect::<Vec<_>>(), 1) {
+                        Ok(latent) => latent,
+                        Err(e) => {
+                            let _ = decode_tx.send(Err(e));
+                            return;
+                        }
+                    },
+                };
+                let pcm = decode_model
+                    .decode_latent(&latent, &mut state)
+                    .and_then(|audio| audio.narrow(0, ..1)?.contiguous()?.to_vec());
+                let failed = pcm.is_err();
+                if decode_tx.send(pcm).is_err() || failed {
+                    return;
+                }
+                if reset_after {
+                    state = mimi_init.clone();
+                }
+            }
+        });
+
+        // Flow-LM: text in, latents out.
+        let model = Arc::clone(&self.model);
+        let backbone_handle = std::thread::spawn(move || {
+            let result = run_backbone(&model, chunks, base_state, cfg_base, rng, ldim, &latent_tx);
+            if let Err(e) = result {
+                let _ = pcm_tx.send(Err(e));
+            }
+        });
+
+        Ok(SpeechStream {
+            rx: pcm_rx,
+            sample_rate: self.sample_rate(),
+            failed: false,
+            workers: Some([backbone_handle, decode_handle]),
+        })
+    }
+
+    /// Split `text` into chunks and work out the budgets for each.
+    fn plan_chunks(&self, text: &str, max_tokens_per_chunk: usize) -> Result<Vec<ChunkPlan>> {
+        let tokenizer = match self.model.flow_lm.conditioner.tokenizer.as_ref() {
+            Some(tokenizer) => tokenizer.as_ref(),
+            None => xn::bail!(
+                "this model was loaded without a tokenizer; pass one to \
+                 SynthBuilder::tokenizer, or use the lower-level TTSModel API with \
+                 pre-tokenized input"
+            ),
+        };
+        let texts = split_into_best_sentences(tokenizer, text, Some(max_tokens_per_chunk))?;
+        let frame_rate = self.cfg.mimi.frame_rate;
+        let mut chunks = Vec::with_capacity(texts.len());
+        for text in texts {
+            let (prepared, frames_after_eos) = prepare_text_prompt(&text);
+            let tokens = self.model.flow_lm.conditioner.tokenize(&prepared)?;
+            let frame_budget = plan::frame_budget(tokens.len(), frame_rate);
+            let seq_budget = plan::seq_budget(tokens.len(), frame_budget);
+            chunks.push(ChunkPlan { tokens, frame_budget, frames_after_eos, seq_budget });
+        }
+        if chunks.is_empty() {
+            xn::bail!("nothing to synthesize: the text is empty");
+        }
+        Ok(chunks)
+    }
+
+    /// Build the state every chunk starts from: allocated, then conditioned on
+    /// the voice. Cloning it per chunk is much cheaper than re-priming.
+    #[allow(clippy::type_complexity)]
+    fn primed_state(
+        &self,
+        voice: Option<&String>,
+        seq_budget: usize,
+        cfg_coef: Option<f32>,
+    ) -> Result<(TTSState<Q>, Option<(f32, TTSState<Q>)>)> {
+        let voice = match voice {
+            None if self.voices.is_empty() => None,
+            None => xn::bail!(
+                "no voice selected; this model has {}",
+                self.voices.keys().cloned().collect::<Vec<_>>().join(", ")
+            ),
+            Some(name) => match self.voices.get(name) {
+                Some(voice) => Some(voice),
+                None => xn::bail!(
+                    "unknown voice '{name}'; available voices are {}",
+                    self.voices.keys().cloned().collect::<Vec<_>>().join(", ")
+                ),
+            },
+        };
+
+        let mut state = self.model.init_flow_lm_state(1, seq_budget)?;
+        if let Some(voice) = voice {
+            self.model.prompt_audio(&mut state, &voice.emb)?;
+        }
+
+        let cfg_state = match cfg_coef {
+            None => None,
+            Some(coef) => {
+                let mut null_state = self.model.init_flow_lm_state(1, seq_budget)?;
+                if !self.cfg.cfg_null_audio_empty
+                    && let Some(voice) = voice
+                {
+                    match voice.null_emb.as_ref() {
+                        Some(null_emb) => self.model.prompt_audio(&mut null_state, null_emb)?,
+                        None => xn::bail!(
+                            "this model conditions its CFG null branch on silence \
+                             (cfg_null_audio_empty=false), which needs the voice's source audio. \
+                             Register the voice with add_voice_from_pcm instead of a precomputed \
+                             embedding, or disable CFG."
+                        ),
+                    }
+                }
+                Some((coef, null_state))
+            }
+        };
+        Ok((state, cfg_state))
+    }
+}
+
+impl<Q: BackendQ> std::fmt::Debug for SynthOf<Q> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SynthOf")
+            .field("device", &self.device_name())
+            .field("sample_rate", &self.sample_rate())
+            .field("voices", &self.voices())
+            .finish()
+    }
+}
+
+/// What one text chunk will need.
+struct ChunkPlan {
+    tokens: Vec<u32>,
+    frame_budget: usize,
+    frames_after_eos: usize,
+    seq_budget: usize,
+}
+
+/// Messages from the flow-LM thread to the decoder thread.
+enum Frame<Q: BackendQ> {
+    Latent(Tensor<Q::T, Q::B>),
+    ChunkEnd,
+}
+
+/// The autoregressive loop, shared by every frontend and every chunk.
+fn run_backbone<Q: BackendQ>(
+    model: &TTSModel<Q>,
+    chunks: Vec<ChunkPlan>,
+    base_state: TTSState<Q>,
+    cfg_base: Option<(f32, TTSState<Q>)>,
+    mut rng: Box<dyn crate::flow_lm::Rng + Send>,
+    ldim: usize,
+    latent_tx: &std::sync::mpsc::Sender<Frame<Q>>,
+) -> Result<()> {
+    let device = model.device().clone();
+    for chunk in chunks.iter() {
+        let mut state = base_state.clone();
+        let mut cfg_state = cfg_base.clone();
+        model.prompt_text(&mut state, &chunk.tokens)?;
+        if let Some((_, null_state)) = cfg_state.as_mut() {
+            model.prompt_text_null(null_state)?;
+        }
+
+        // A NaN latent marks the start of the sequence.
+        let nan = vec![f32::NAN; ldim];
+        let mut prev: Tensor<Q::T, Q::B> =
+            Tensor::from_vec(nan, (1, 1, ldim), &device)?.to::<Q::T>()?;
+        let mut eos = EosPolicy::new(chunk.frames_after_eos);
+
+        for _ in 0..chunk.frame_budget {
+            let (next, is_eos) = match cfg_state.as_mut() {
+                Some((coef, null_state)) => {
+                    model.generate_step_cfg(&mut state, null_state, *coef, &prev, &mut rng)?
+                }
+                None => model.generate_step(&mut state, &prev, &mut rng)?,
+            };
+            // A closed channel means the consumer went away; stop quietly and
+            // let the decoder thread report any error of its own.
+            if latent_tx.send(Frame::Latent(next.clone())).is_err() {
+                return Ok(());
+            }
+            if eos.should_stop(is_eos) {
+                break;
+            }
+            prev = next;
+        }
+        if latent_tx.send(Frame::ChunkEnd).is_err() {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+/// PCM chunks from a running generation.
+///
+/// Each item is mono `f32` samples at [`Self::sample_rate`] — one Mimi frame's
+/// worth, or several when the decoder finds more than one frame already queued
+/// and decodes them together. The iterator ends when generation finishes; an
+/// `Err` item is terminal.
+pub struct SpeechStream {
+    rx: std::sync::mpsc::Receiver<Result<Vec<f32>>>,
+    sample_rate: usize,
+    failed: bool,
+    /// The flow-LM and decoder threads, joined once the channel closes so that
+    /// a panic in either surfaces as an error rather than as truncated audio.
+    workers: Option<[std::thread::JoinHandle<()>; 2]>,
+}
+
+impl SpeechStream {
+    pub fn sample_rate(&self) -> usize {
+        self.sample_rate
+    }
+}
+
+impl Iterator for SpeechStream {
+    type Item = Result<Vec<f32>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.failed {
+            return None;
+        }
+        match self.rx.recv() {
+            Ok(Err(e)) => {
+                self.failed = true;
+                self.workers.take();
+                Some(Err(e))
+            }
+            Ok(ok) => Some(ok),
+            // Every sender dropped: generation finished, or a worker died.
+            Err(_) => {
+                self.failed = true;
+                let workers = self.workers.take()?;
+                let died = workers.into_iter().any(|h| h.join().is_err());
+                if died {
+                    Some(Err(xn::Error::msg(
+                        "a generation worker panicked; the audio is incomplete",
+                    )))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+/// Configures and loads a [`Synth`].
+pub struct SynthBuilder {
+    source: ModelSource,
+    device: DeviceKind,
+    quant: Quant,
+    tokenizer: Option<Box<dyn crate::Tokenizer + Send + Sync>>,
+    temperature: f32,
+    seed: u64,
+    cfg_coef: Option<f32>,
+    eos_threshold: Option<f32>,
+    voice: Option<String>,
+    max_tokens_per_chunk: usize,
+    extra_voices: Vec<(String, PathBuf)>,
+}
+
+impl Default for SynthBuilder {
+    fn default() -> Self {
+        Self {
+            source: ModelSource::hub(),
+            device: DeviceKind::Auto,
+            quant: Quant::F32,
+            tokenizer: None,
+            temperature: 0.7,
+            seed: 4242424242424242,
+            cfg_coef: None,
+            eos_threshold: None,
+            voice: None,
+            max_tokens_per_chunk: MAX_TOKENS_PER_CHUNK,
+            extra_voices: vec![],
+        }
+    }
+}
+
+impl SynthBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Where to load the checkpoint from. Defaults to the published repo on the
+    /// Hugging Face Hub.
+    pub fn source(mut self, source: ModelSource) -> Self {
+        self.source = source;
+        self
+    }
+
+    /// Load from a local directory holding `config.json`, weights, a tokenizer
+    /// and an optional `voices/` subdirectory.
+    pub fn dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.source = ModelSource::Dir(dir.into());
+        self
+    }
+
+    pub fn device(mut self, device: DeviceKind) -> Self {
+        self.device = device;
+        self
+    }
+
+    /// Weight format for the flow-LM transformer linears. CPU only.
+    pub fn quant(mut self, quant: Quant) -> Self {
+        self.quant = quant;
+        self
+    }
+
+    /// Supply the tokenizer explicitly. Required when the checkpoint ships no
+    /// tokenizer file, or when neither the `sp` nor the `hf` feature is enabled.
+    pub fn tokenizer(mut self, tokenizer: Box<dyn crate::Tokenizer + Send + Sync>) -> Self {
+        self.tokenizer = Some(tokenizer);
+        self
+    }
+
+    pub fn temperature(mut self, temperature: f32) -> Self {
+        self.temperature = temperature;
+        self
+    }
+
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    /// Classifier-free guidance coefficient applied to every request. `1.0`
+    /// disables it.
+    pub fn cfg_coef(mut self, cfg_coef: f32) -> Self {
+        self.cfg_coef = Some(cfg_coef);
+        self
+    }
+
+    /// Override the config's EOS log-probability threshold. Lower values let
+    /// the model run longer before it decides an utterance is finished.
+    pub fn eos_threshold(mut self, eos_threshold: f32) -> Self {
+        self.eos_threshold = Some(eos_threshold);
+        self
+    }
+
+    /// Default voice for requests that do not name one.
+    pub fn voice(mut self, voice: impl Into<String>) -> Self {
+        self.voice = Some(voice.into());
+        self
+    }
+
+    /// Maximum text tokens per synthesized chunk. Longer text is split on
+    /// sentence boundaries.
+    pub fn max_tokens_per_chunk(mut self, max_tokens: usize) -> Self {
+        self.max_tokens_per_chunk = max_tokens;
+        self
+    }
+
+    /// Register an extra precomputed voice embedding at load time.
+    pub fn add_voice(mut self, name: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        self.extra_voices.push((name.into(), path.into()));
+        self
+    }
+
+    /// Locate the checkpoint, load it, and register its voices.
+    pub fn build(self) -> Result<Synth> {
+        let device = self.device.resolve();
+        if device != DeviceKind::Cpu && self.quant != Quant::F32 {
+            xn::bail!(
+                "quantization ({}) is CPU-only, but the selected device is {device:?}",
+                self.quant.as_str()
+            );
+        }
+        match device {
+            DeviceKind::Cpu => self.build_cpu(),
+            DeviceKind::Cuda => self.build_cuda(),
+            DeviceKind::Vulkan => self.build_vulkan(),
+            DeviceKind::Metal => self.build_metal(),
+            DeviceKind::Auto => unreachable!("resolved above"),
+        }
+    }
+
+    fn build_cpu(self) -> Result<Synth> {
+        macro_rules! cpu {
+            ($variant:ident, $q:ty) => {{
+                let synth = self.load::<$q>(xn::CPU)?;
+                Ok(Synth(SynthV::$variant(synth)))
+            }};
+        }
+        match self.quant {
+            Quant::F32 => cpu!(Cpu, xn::Unquantized<f32, xn::CpuDevice>),
+            Quant::Q80 => cpu!(Q80, xn::quantized::Q80F32),
+            Quant::Q81 => cpu!(Q81, xn::quantized::Q81F32),
+            Quant::Q8k => cpu!(Q8k, xn::quantized::Q8kF32),
+            Quant::Q6k => cpu!(Q6k, xn::quantized::Q6kF32),
+            Quant::Q50 => cpu!(Q50, xn::quantized::Q50F32),
+            Quant::Q51 => cpu!(Q51, xn::quantized::Q51F32),
+            Quant::Q5k => cpu!(Q5k, xn::quantized::Q5kF32),
+            Quant::Q40 => cpu!(Q40, xn::quantized::Q40F32),
+            Quant::Q41 => cpu!(Q41, xn::quantized::Q41F32),
+            Quant::Q4k => cpu!(Q4k, xn::quantized::Q4kF32),
+        }
+    }
+
+    #[cfg(feature = "cuda")]
+    fn build_cuda(self) -> Result<Synth> {
+        let dev = xn::cuda_backend::Device::new(0)?;
+        // Event tracking costs a few percent and this workload never queries events.
+        unsafe { dev.disable_event_tracking() };
+        let synth = self.load::<xn::Unquantized<half::bf16, _>>(dev)?;
+        Ok(Synth(SynthV::Cuda(synth)))
+    }
+
+    #[cfg(feature = "vulkan")]
+    fn build_vulkan(self) -> Result<Synth> {
+        let dev = xn::vulkan_backend::Device::new(0)?;
+        let synth = self.load::<xn::Unquantized<f32, _>>(dev)?;
+        Ok(Synth(SynthV::Vulkan(synth)))
+    }
+
+    #[cfg(feature = "metal")]
+    fn build_metal(self) -> Result<Synth> {
+        let dev = xn::metal_backend::Device::new(0)?;
+        let synth = self.load::<xn::Unquantized<half::bf16, _>>(dev)?;
+        Ok(Synth(SynthV::Metal(synth)))
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    fn build_cuda(self) -> Result<Synth> {
+        xn::bail!("this build has no CUDA support; rebuild with the `cuda` feature")
+    }
+
+    #[cfg(not(feature = "vulkan"))]
+    fn build_vulkan(self) -> Result<Synth> {
+        xn::bail!("this build has no Vulkan support; rebuild with the `vulkan` feature")
+    }
+
+    #[cfg(not(feature = "metal"))]
+    fn build_metal(self) -> Result<Synth> {
+        xn::bail!("this build has no Metal support; rebuild with the `metal` feature")
+    }
+
+    /// Resolve the source, load the weights, and register voices.
+    fn load<Q: BackendQ>(mut self, device: Q::B) -> Result<SynthOf<Q>> {
+        let Artifacts { config, weights, tokenizer: tokenizer_path, voices } =
+            self.source.resolve(self.temperature)?;
+
+        let tokenizer = self.take_tokenizer(tokenizer_path.as_deref())?;
+
+        let vb = loader::load_weights::<Q>(&weights, &device)?;
+        let model = TTSModel::<Q>::load(&vb, tokenizer, &config)?;
+        let model = match self.eos_threshold {
+            Some(threshold) => model.with_eos_threshold(threshold),
+            None => model,
+        };
+        // A dedicated speaker codec ships its encoder under its own prefix, so
+        // probe there rather than assuming `mimi.encoder.*`.
+        let probe = format!("{}.encoder.model.0.conv.weight", config.speaker_mimi_prefix());
+        let mimi_enc =
+            if vb.contains(&probe) { Some(MimiEnc::<Q>::load(&vb, &config)?) } else { None };
+        vb.check_all_used_with_ignore(loader::is_unused_by_tts_model)?;
+
+        let mut synth = SynthOf {
+            model: Arc::new(model),
+            mimi_enc,
+            cfg: config,
+            voices: BTreeMap::new(),
+            defaults: Defaults {
+                voice: self.voice.clone(),
+                temperature: self.temperature,
+                seed: self.seed,
+                cfg_coef: self.cfg_coef,
+                max_tokens_per_chunk: self.max_tokens_per_chunk,
+            },
+        };
+
+        // A voice that ships with the checkpoint but fails to load is skipped:
+        // one bad embedding should not make the model unusable. A voice the
+        // caller asked for by path is a hard error.
+        for (name, path) in voices.iter() {
+            if let Err(e) = synth.add_voice_file(name, path) {
+                tracing::warn!(voice = %name, error = %e, "skipping voice embedding");
+            }
+        }
+        for (name, path) in self.extra_voices.iter() {
+            synth.add_voice_file(name, path)?;
+        }
+
+        // Default to the first voice by name when the caller named none, so a
+        // bare `say` works out of the box.
+        if synth.defaults.voice.is_none() {
+            synth.defaults.voice = synth.voices.keys().next().cloned();
+        }
+        if let Some(name) = synth.defaults.voice.as_ref()
+            && !synth.voices.contains_key(name)
+        {
+            xn::bail!(
+                "default voice '{name}' was not found; available voices are {}",
+                synth.voices.keys().cloned().collect::<Vec<_>>().join(", ")
+            );
+        }
+        Ok(synth)
+    }
+
+    /// A caller-supplied tokenizer wins — `ptts-wasm` tokenizes in JavaScript
+    /// and has no tokenizer file at all. Otherwise load the one the checkpoint
+    /// shipped, if a tokenizer backend is compiled in.
+    fn take_tokenizer(
+        &mut self,
+        path: Option<&FsPath>,
+    ) -> Result<Box<dyn crate::Tokenizer + Send + Sync>> {
+        if let Some(tokenizer) = self.tokenizer.take() {
+            return Ok(tokenizer);
+        }
+        #[cfg(any(feature = "sp", feature = "hf"))]
+        if let Some(path) = path {
+            return Ok(Box::new(crate::tok::Tok::open(path)?));
+        }
+        let _ = path;
+        xn::bail!(
+            "no tokenizer available: the checkpoint ships none, and neither the `sp` nor the \
+             `hf` feature of `ptts` is enabled. Pass one to SynthBuilder::tokenizer."
+        )
+    }
+}
+
+/// Every weight format and device this build supports.
+///
+/// [`Synth`] exists so that a caller who picks a format from a command-line
+/// flag or a config file does not have to be generic over `Q`. The runtime
+/// dispatch happens once per method call and costs nothing next to a
+/// transformer step.
+enum SynthV {
+    Cpu(SynthOf<xn::Unquantized<f32, xn::CpuDevice>>),
+    Q80(SynthOf<xn::quantized::Q80F32>),
+    Q81(SynthOf<xn::quantized::Q81F32>),
+    Q8k(SynthOf<xn::quantized::Q8kF32>),
+    Q6k(SynthOf<xn::quantized::Q6kF32>),
+    Q50(SynthOf<xn::quantized::Q50F32>),
+    Q51(SynthOf<xn::quantized::Q51F32>),
+    Q5k(SynthOf<xn::quantized::Q5kF32>),
+    Q40(SynthOf<xn::quantized::Q40F32>),
+    Q41(SynthOf<xn::quantized::Q41F32>),
+    Q4k(SynthOf<xn::quantized::Q4kF32>),
+    #[cfg(feature = "cuda")]
+    Cuda(SynthOf<xn::Unquantized<half::bf16, xn::cuda_backend::Device>>),
+    #[cfg(feature = "vulkan")]
+    Vulkan(SynthOf<xn::Unquantized<f32, xn::vulkan_backend::Device>>),
+    #[cfg(feature = "metal")]
+    Metal(SynthOf<xn::Unquantized<half::bf16, xn::metal_backend::Device>>),
+}
+
+/// Forward a method to whichever [`SynthOf`] is inside, binding it to `$s`.
+macro_rules! dispatch {
+    ($synth:expr, |$s:ident| $body:expr) => {
+        match $synth {
+            SynthV::Cpu($s) => $body,
+            SynthV::Q80($s) => $body,
+            SynthV::Q81($s) => $body,
+            SynthV::Q8k($s) => $body,
+            SynthV::Q6k($s) => $body,
+            SynthV::Q50($s) => $body,
+            SynthV::Q51($s) => $body,
+            SynthV::Q5k($s) => $body,
+            SynthV::Q40($s) => $body,
+            SynthV::Q41($s) => $body,
+            SynthV::Q4k($s) => $body,
+            #[cfg(feature = "cuda")]
+            SynthV::Cuda($s) => $body,
+            #[cfg(feature = "vulkan")]
+            SynthV::Vulkan($s) => $body,
+            #[cfg(feature = "metal")]
+            SynthV::Metal($s) => $body,
+        }
+    };
+}
+
+/// A loaded Pocket TTS model, ready to synthesize speech.
+///
+/// See the [module docs](self) for the short version. The weight format and
+/// device are chosen at load time by [`SynthBuilder`] and erased here.
+pub struct Synth(SynthV);
+
+impl Synth {
+    /// Load the published checkpoint from the Hugging Face Hub with default
+    /// settings: unquantized weights, the best available device, and the first
+    /// bundled voice.
+    ///
+    /// Requires the `hub` feature, plus `sp` or `hf` for the tokenizer.
+    pub fn from_hub() -> Result<Self> {
+        Self::builder().build()
+    }
+
+    /// Load from a local directory holding `config.json`, a weights file, a
+    /// tokenizer and an optional `voices/` subdirectory.
+    pub fn from_dir(dir: impl Into<PathBuf>) -> Result<Self> {
+        Self::builder().dir(dir).build()
+    }
+
+    pub fn builder() -> SynthBuilder {
+        SynthBuilder::new()
+    }
+
+    /// Synthesize `text` and return the whole waveform as mono `f32` at
+    /// [`Self::sample_rate`].
+    pub fn say(&self, text: &str) -> Result<Vec<f32>> {
+        dispatch!(&self.0, |s| s.say(text))
+    }
+
+    /// Synthesize `text` with per-request overrides.
+    pub fn say_with(&self, text: &str, opts: &SpeechOptions) -> Result<Vec<f32>> {
+        dispatch!(&self.0, |s| s.say_with(text, opts))
+    }
+
+    /// Start generating `text`, yielding PCM as the decoder produces it.
+    pub fn stream(&self, text: &str) -> Result<SpeechStream> {
+        dispatch!(&self.0, |s| s.stream(text))
+    }
+
+    /// Start generating `text` with per-request overrides.
+    pub fn stream_with(&self, text: &str, opts: &SpeechOptions) -> Result<SpeechStream> {
+        dispatch!(&self.0, |s| s.stream_with(text, opts))
+    }
+
+    /// As [`Self::stream_with`], but with an explicit noise source — see
+    /// [`SynthOf::stream_with_rng`].
+    pub fn stream_with_rng(
+        &self,
+        text: &str,
+        opts: &SpeechOptions,
+        rng: Box<dyn crate::flow_lm::Rng + Send>,
+    ) -> Result<SpeechStream> {
+        dispatch!(&self.0, |s| s.stream_with_rng(text, opts, rng))
+    }
+
+    pub fn sample_rate(&self) -> usize {
+        dispatch!(&self.0, |s| s.sample_rate())
+    }
+
+    pub fn config(&self) -> &TTSConfig {
+        dispatch!(&self.0, |s| s.config())
+    }
+
+    /// Name of the device the model is running on, e.g. `"cpu"` or `"cuda:0"`.
+    pub fn device_name(&self) -> String {
+        dispatch!(&self.0, |s| s.device_name())
+    }
+
+    /// Registered voice names, sorted.
+    pub fn voices(&self) -> Vec<String> {
+        dispatch!(&self.0, |s| s.voices())
+    }
+
+    /// True if this checkpoint carries a speaker encoder, which
+    /// [`Self::add_voice_from_pcm`] requires.
+    pub fn supports_voice_cloning(&self) -> bool {
+        dispatch!(&self.0, |s| s.supports_voice_cloning())
+    }
+
+    /// The sample rate [`Self::add_voice_from_pcm`] expects.
+    pub fn voice_prompt_sample_rate(&self) -> usize {
+        dispatch!(&self.0, |s| s.voice_prompt_sample_rate())
+    }
+
+    /// Register a precomputed voice embedding, replacing any voice of the same name.
+    pub fn add_voice_file(&mut self, name: &str, path: &FsPath) -> Result<()> {
+        dispatch!(&mut self.0, |s| s.add_voice_file(name, path))
+    }
+
+    /// Clone a voice from a mono audio prompt at
+    /// [`Self::voice_prompt_sample_rate`].
+    pub fn add_voice_from_pcm(&mut self, name: &str, pcm: &[f32]) -> Result<()> {
+        dispatch!(&mut self.0, |s| s.add_voice_from_pcm(name, pcm))
+    }
+
+    /// The weight format actually loaded. GPU backends are always unquantized.
+    pub fn quant(&self) -> Quant {
+        match &self.0 {
+            SynthV::Cpu(_) => Quant::F32,
+            SynthV::Q80(_) => Quant::Q80,
+            SynthV::Q81(_) => Quant::Q81,
+            SynthV::Q8k(_) => Quant::Q8k,
+            SynthV::Q6k(_) => Quant::Q6k,
+            SynthV::Q50(_) => Quant::Q50,
+            SynthV::Q51(_) => Quant::Q51,
+            SynthV::Q5k(_) => Quant::Q5k,
+            SynthV::Q40(_) => Quant::Q40,
+            SynthV::Q41(_) => Quant::Q41,
+            SynthV::Q4k(_) => Quant::Q4k,
+            #[cfg(feature = "cuda")]
+            SynthV::Cuda(_) => Quant::F32,
+            #[cfg(feature = "vulkan")]
+            SynthV::Vulkan(_) => Quant::F32,
+            #[cfg(feature = "metal")]
+            SynthV::Metal(_) => Quant::F32,
+        }
+    }
+}
+
+impl std::fmt::Debug for Synth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Synth")
+            .field("device", &self.device_name())
+            .field("weights", &self.quant().as_str())
+            .field("sample_rate", &self.sample_rate())
+            .field("voices", &self.voices())
+            .finish()
+    }
+}

--- a/ptts/src/wav.rs
+++ b/ptts/src/wav.rs
@@ -54,3 +54,20 @@ pub fn write_pcm_as_wav<W: Write, S: Sample>(
     }
     Ok(())
 }
+
+/// Write mono PCM to a WAV file at `path`.
+///
+/// A convenience over [`write_pcm_as_wav`] for the common case of saving a
+/// finished [`crate::synth::Synth::say`] result.
+pub fn write_wav_file<P: AsRef<std::path::Path>>(
+    path: P,
+    pcm: &[f32],
+    sample_rate: u32,
+) -> xn::Result<()> {
+    let file = std::fs::File::create(path.as_ref())
+        .map_err(|e| xn::Error::msg(format!("cannot create {}: {e}", path.as_ref().display())))?;
+    let mut writer = std::io::BufWriter::new(file);
+    write_pcm_as_wav(&mut writer, pcm, sample_rate, 1).map_err(xn::Error::wrap)?;
+    writer.flush().map_err(xn::Error::wrap)?;
+    Ok(())
+}

--- a/ptts/tests/synth_api.rs
+++ b/ptts/tests/synth_api.rs
@@ -1,0 +1,167 @@
+//! Exercises everything about `Synth` that does not need model weights.
+//!
+//! The generation path itself needs a checkpoint, so it is covered by the
+//! examples rather than here. What is testable without one is the surface most
+//! likely to break for a first-time user: argument parsing, feature gating, and
+//! the error messages on the paths they will hit by accident.
+
+use ptts::loader::ModelSource;
+use ptts::synth::{DeviceKind, Quant, SpeechOptions, Synth};
+
+#[test]
+fn quant_parses_every_spelling_the_clis_accept() {
+    let cases = [
+        ("f32", Quant::F32),
+        ("none", Quant::F32),
+        ("q8", Quant::Q80),
+        ("q8_0", Quant::Q80),
+        ("q8_1", Quant::Q81),
+        ("q8k", Quant::Q8k),
+        ("q6k", Quant::Q6k),
+        ("q5", Quant::Q50),
+        ("q5_0", Quant::Q50),
+        ("q5_1", Quant::Q51),
+        ("q5k", Quant::Q5k),
+        ("q4", Quant::Q40),
+        ("q4_0", Quant::Q40),
+        ("q4_1", Quant::Q41),
+        ("q4k", Quant::Q4k),
+    ];
+    for (name, expected) in cases {
+        assert_eq!(Quant::parse(name).unwrap(), expected, "parsing {name}");
+    }
+}
+
+#[test]
+fn quant_round_trips_through_its_canonical_name() {
+    for quant in [
+        Quant::F32,
+        Quant::Q80,
+        Quant::Q81,
+        Quant::Q8k,
+        Quant::Q6k,
+        Quant::Q50,
+        Quant::Q51,
+        Quant::Q5k,
+        Quant::Q40,
+        Quant::Q41,
+        Quant::Q4k,
+    ] {
+        assert_eq!(Quant::parse(quant.as_str()).unwrap(), quant);
+    }
+}
+
+#[test]
+fn unknown_quant_lists_the_valid_ones() {
+    let err = Quant::parse("q3k").unwrap_err().to_string();
+    assert!(err.contains("q3k"), "{err}");
+    assert!(err.contains("q4k"), "should list the supported formats: {err}");
+}
+
+#[test]
+fn device_parses_and_rejects_unknown_names() {
+    assert_eq!(DeviceKind::parse("auto").unwrap(), DeviceKind::Auto);
+    assert_eq!(DeviceKind::parse("cpu").unwrap(), DeviceKind::Cpu);
+    assert_eq!(DeviceKind::parse("cuda").unwrap(), DeviceKind::Cuda);
+    assert_eq!(DeviceKind::parse("vulkan").unwrap(), DeviceKind::Vulkan);
+    assert_eq!(DeviceKind::parse("metal").unwrap(), DeviceKind::Metal);
+    let err = DeviceKind::parse("tpu").unwrap_err().to_string();
+    assert!(err.contains("tpu"), "{err}");
+}
+
+#[test]
+fn auto_resolves_to_something_concrete() {
+    let resolved = DeviceKind::Auto.resolve();
+    assert_ne!(resolved, DeviceKind::Auto);
+    // With no GPU feature enabled, `auto` must land on the CPU.
+    if !cfg!(any(feature = "cuda", feature = "vulkan", feature = "metal")) {
+        assert_eq!(resolved, DeviceKind::Cpu);
+    }
+}
+
+#[test]
+fn explicit_device_survives_resolution() {
+    for device in [DeviceKind::Cpu, DeviceKind::Cuda, DeviceKind::Vulkan, DeviceKind::Metal] {
+        assert_eq!(device.resolve(), device);
+    }
+}
+
+#[test]
+fn quantization_on_a_gpu_is_rejected_before_any_download() {
+    let err = Synth::builder()
+        .device(DeviceKind::Cuda)
+        .quant(Quant::Q40)
+        .build()
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("CPU-only"), "{err}");
+    assert!(err.contains("q4_0"), "the error should name the format: {err}");
+}
+
+#[test]
+fn a_missing_directory_names_itself() {
+    let err = Synth::from_dir("/definitely/not/a/model/dir").unwrap_err().to_string();
+    assert!(err.contains("/definitely/not/a/model/dir"), "{err}");
+}
+
+#[test]
+fn an_empty_directory_lists_the_weight_files_it_looked_for() {
+    let dir = std::env::temp_dir().join("ptts-synth-api-empty-dir");
+    std::fs::create_dir_all(&dir).unwrap();
+    let err = Synth::from_dir(&dir).unwrap_err().to_string();
+    assert!(err.contains("model.safetensors"), "should list the candidates: {err}");
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn missing_explicit_weights_name_the_path() {
+    let source = ModelSource::Files {
+        config: None,
+        weights: "/nope/weights.safetensors".into(),
+        tokenizer: None,
+    };
+    let err = source.resolve(0.7).unwrap_err().to_string();
+    assert!(err.contains("/nope/weights.safetensors"), "{err}");
+}
+
+#[test]
+fn an_unparseable_config_names_the_file() {
+    let path = std::env::temp_dir().join("ptts-synth-api-bad-config.json");
+    std::fs::write(&path, "{ not json").unwrap();
+    let source =
+        ModelSource::Files { config: Some(path.clone()), weights: "/nope".into(), tokenizer: None };
+    let err = source.resolve(0.7).unwrap_err().to_string();
+    assert!(err.contains("ptts-synth-api-bad-config.json"), "{err}");
+    std::fs::remove_file(&path).ok();
+}
+
+#[cfg(not(feature = "hub"))]
+#[test]
+fn the_hub_path_says_which_feature_is_missing() {
+    let err = Synth::from_hub().unwrap_err().to_string();
+    assert!(err.contains("hub"), "{err}");
+}
+
+#[test]
+fn speech_options_build_up_fluently() {
+    let opts = SpeechOptions::default()
+        .voice("alba")
+        .temperature(0.5)
+        .seed(7)
+        .cfg_coef(1.5)
+        .max_tokens_per_chunk(32);
+    assert_eq!(opts.voice.as_deref(), Some("alba"));
+    assert_eq!(opts.temperature, Some(0.5));
+    assert_eq!(opts.seed, Some(7));
+    assert_eq!(opts.cfg_coef, Some(1.5));
+    assert_eq!(opts.max_tokens_per_chunk, Some(32));
+}
+
+#[test]
+fn speech_options_default_to_the_builders_settings() {
+    let opts = SpeechOptions::default();
+    assert!(opts.voice.is_none());
+    assert!(opts.temperature.is_none());
+    assert!(opts.seed.is_none());
+    assert!(opts.cfg_coef.is_none());
+}


### PR DESCRIPTION
# Add `ptts::Synth`, a one-call synthesis API

## Summary

The base PR gathered the loading helpers every frontend was copying into `ptts::loader` and
`ptts::tok`. This one goes the rest of the way: it adds the API that means a caller never has to
assemble the pipeline at all.

```rust
let tts = Synth::from_hub()?;
let pcm = tts.say("Hello world")?;
ptts::wav::write_wav_file("out.wav", &pcm, tts.sample_rate() as u32)?;
```

`TTSModel` exposes streaming primitives — `init_flow_lm_state`, `prompt_audio`, `generate_step`,
`decode_latent` — and nothing that composes them, so every frontend composed them itself. `Synth`
is that composition, kept in the library where all four frontends and any third-party crate can
reach it. Nothing existing under `ptts/src` changes behavior; the primitives stay public and are
documented as the path for callers that need to drive generation themselves.

`ptts/examples/pocket_tts.rs` goes **575 → 225 lines**, of which the synthesis is ~30. A new
16-line `examples/say.rs` is the whole quickstart, readable as documentation.

## What this adds on top of the base

| | |
|---|---|
| `ptts::synth` (new, 1057) | `Synth`, `SynthOf<Q>`, `SynthBuilder`, `SpeechStream`, `SpeechOptions`, `Quant`, `DeviceKind` |
| `ptts::plan` (new, 169) | `frame_budget`, `seq_budget`, `EosPolicy` |
| `ptts::loader` (+263) | `ModelSource`, `Artifacts`, the `hub` feature, plus a header-only metadata read |
| `ptts::flow_lm` (+80) | `ReplayRng`, `impl Rng for Box<dyn Rng + Send>`, and tests for `NormalRng` |
| `ptts::wav` (+17) | `write_wav_file` |
| `ptts/src/lib.rs` (+39) | crate docs and an architecture table |

`Synth` is type-erased over eleven CPU weight formats and three GPU backends, so a caller reading
`--quant` from a flag does not have to be generic over `Q`. Callers that *want* to name the format
— `ptts-wasm` supports exactly two — use `SynthOf<Q>` and skip the dispatch. That erasure is the
same trick `ptts-pyo3`'s `ModelV` and `ptts-ws-server`'s `AppState` each already implement
privately; there is now one copy to port them onto.

### Deliberately reusing the base rather than duplicating it

Working on top of the base branch removed about 300 lines this change would otherwise have
carried. Specifically, this PR **does not** add its own copy of:

- `remap_key`, `is_unused_by_tts_model`, `load_weights`, `load_voice_emb` — `ptts::loader` has them.
- A tokenizer enum — `ptts::tok::Tok::open` has it.
- A Gaussian noise source — `ptts::flow_lm::NormalRng` has it. Only `ReplayRng` is new, and it
  goes next to `NormalRng` rather than into a module of its own.

`ModelSource` lands in `loader.rs` because that module's job is already "reading checkpoints off
disk"; deciding *which* files, across the three layouts in use, belongs beside reading them.

### Two things the base left duplicated, now retired

- `model_helpers::max_frames_for` hardcoded `12.5`, the codec frame rate. `bench.rs` now calls
  `plan::frame_budget(n, cfg.mimi.frame_rate)`, and `model_helpers` is pure re-exports.
- `bench.rs` carried the last in-crate copy of the EOS countdown; it now uses `plan::EosPolicy`.

Three literal copies of the frame budget remain, all outside `ptts/src`: `ptts-pyo3` (twice),
`ptts-wasm` and `ptts-ws-server`. Porting those is the follow-up.

### One generation path, not two

`say()` is `stream().collect()`. `stream()` keeps the two-thread pipeline the example and the
server both had, flow-LM on one thread, Mimi decode on the other, so decoding overlaps the next
backbone step, and it is the only implementation. `ptts-pyo3` currently carries `run_generate`
and `run_generate_background` as near-identical 90-line copies of that loop.

Cancellation falls out of the channel topology: dropping the `SpeechStream` drops the receiver,
the decoder's next `send` fails, its latent receiver drops, and the backbone's `send` fails in
turn. Both threads exit without an `is_done` flag.

## Feature and dependency changes

| Change | Why |
|---|---|
| `hub` feature (new), `hf-hub` optional | `hf-hub` was a `[dev-dependency]`, so a crate depending on `ptts` got **no weight loading at all**. Optional because it pulls `ureq`, which must not reach the wasm build. |
| `serde_json` promoted to `[dependencies]` | `ModelSource` parses `config.json`. Pure Rust, wasm-safe. |
| `say` and `pocket_tts` examples require `["sp", "hub"]` | both download from the Hub |

`cargo check -p ptts-wasm --target wasm32-unknown-unknown` still pulls in no `hf-hub`.

## Behavior changes

Preserving the old behavior was the goal; these are the places where I did not.

1. **Multi-chunk with CFG.** The example primed one null state outside the chunk loop and then
   called `prompt_text_null` on that *same* state for every chunk, while cloning the conditioned
   state fresh each time — so the null branch accumulated across chunks and would eventually
   outgrow its budget. `Synth` clones it per chunk. Single-chunk output, which is every use of
   `--cfg-coef` I can find, is unchanged.
2. **`frame_rate` comes from the config** rather than a hardcoded `12.5`. Identical for the
   shipped config; correct for any other.
3. **Precomputed voice + CFG** was an unconditional `bail!`. It now works when
   `cfg_null_audio_empty`, and otherwise fails with a message naming the fix.
   `add_voice_from_pcm` caches the silence encoding at registration so the source audio need not
   be retained.
4. **Empty text** errors with "nothing to synthesize: the text is empty" instead of reaching
   `Tensor::cat` with an empty slice.
5. **A panicking worker is reported.** `SpeechStream` holds both `JoinHandle`s and joins them when
   the channel closes, so a panic surfaces as an error rather than as silently truncated audio —
   matching the `.join().map_err(...)` the example used to do.
6. **`load_voice_emb` reads only the safetensors header** for its `model_ext` check instead of the
   whole file. It runs once per voice at load time and the published repo ships eight.

### CLI changes to `pocket_tts`

| Before | After |
|---|---|
| `--cpu` | `--device <auto\|cpu\|cuda\|vulkan\|metal>`, default `auto` |
| `--config <config.json>` | `--dir <dir>` (finds `config.json`, weights, tokenizer, `voices/`) |
| `--weights`, `--wait-to-decode`, `--pad-to` | dropped |
| `--rng-values` | kept, via `Synth::stream_with_rng` |
| `--lang`, `--voice`, `--temperature`, `--seed`, `--quant`, `--cfg-coef`, `--chrome-tracing` | unchanged |

`--lang` and its `ptts::preprocess::normalize_text` call are preserved verbatim from the base;
normalization runs on the text before anything reaches `Synth`, since it is a property of the
text rather than of the model. Folding it into `SpeechOptions` is a follow-up, not a silent
change here.

`--wait-to-decode` and `--pad-to` are instrumentation rather than user-facing options, and the
primitives they drove (`prompt_text_with_padding`, manual step/decode interleaving) are still
public — `bench.rs` is where they belong. Say so and I will restore them.

`stream_with_rng` exists so `--rng-values` did not need a second copy of the loop. It also makes
the crate usable for the reproducibility check contributors need: the sampler's only randomness
is the `Rng` trait, so replaying a recorded sequence compares this implementation against the
reference one step for step.

## Correctness

`EosPolicy` is tested against the pre-refactor loop, transcribed verbatim into the test module as
a reference implementation, over every combination of `frames_after_eos ∈ {0,1,3}`,
`eos_at ∈ {none,0,1,5,19}` and `max_frames ∈ {1,6,20}` — the two must agree on the exact frame
count emitted. `frame_budget` is checked against the literal the frontends carried.

`ptts/tests/synth_api.rs` covers what is reachable without weights, which is the surface a
first-time user hits by accident: every `--quant` spelling and its round-trip, unknown quant and
device names, `auto` resolution, quantization-on-GPU rejected *before* any download, and the error
text for a missing directory, an empty directory, missing explicit weights and an unparseable
config. Each asserts the message names what went wrong.

`NormalRng` arrived on the base branch untested; it now has seed-reproducibility,
seed-independence and zero-temperature tests alongside `ReplayRng`'s.

## Testing

CI-equivalent, with `.cargo/config.toml` removed as CI does, against xn 0.2.4:

| Check | Result |
|---|---|
| `cargo check -p ptts --all-targets --features sp,hub` | clean |
| `cargo check --workspace` | clean, `ptts-ws-server` included |
| `cargo clippy --workspace -- -D warnings` | clean |
| `cargo clippy -p ptts --lib` × features `{}`, `hub`, `sp`, `hf`, `sp+hub`, `hf+hub`, `sp+hf+hub` | clean (`-D warnings`), all 7 |
| `cargo clippy -p ptts --lib --examples --tests --features sp,hub -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo test -p ptts --lib --features sp,hub` | 17 passed |
| `cargo test -p ptts --test synth_api --features sp,hub` | 13 passed |
| `cargo test -p ptts --test synth_api` (no features) | 14 passed |
| `cargo test -p ptts --doc --features sp,hub` | 3 passed |
| `cargo doc -p ptts --no-deps --features sp,hub` | clean, no warnings |
| `git merge-tree feat/synth-on-loader upstream/main` | no conflicts |

**Not covered: no audio was generated.** The weights sit behind `kyutai/pocket-tts`, which is
gated and returns 401 without a token, so the generation path is compile- and logic-verified only.
Someone with access should run `--example say` and A/B a `--rng-values` run against the base
branch before this merges. That is the check I could not do, and it is the one that matters most.

## Follow-ups, not in scope

- **Port the other three frontends onto `Synth`.** `ptts-ws-server` (1457 lines) first, since the
  base PR already brought it into CI. Then `ptts-pyo3` (1201), which additionally sheds one of its
  two generation loops. Then `ptts-wasm` (448), which wants `SynthOf<Q>` rather than `Synth`.
- **CI enables no features**, so `ptts::synth`'s hub path, `ptts::tok` and both Hub-using examples
  are only checked locally. `--features sp,hub` on the check job would cover them.
- Fold `preprocess::normalize_text` into `SpeechOptions` so callers get normalization without
  reaching for it themselves.
- `Synth` has no batching. Every frontend is `batch_size = 1` today, so nothing regresses, but a
  server wanting throughput needs it and the primitives already take a batch argument.
- `SpeechOptions` can select a voice only by name, not by embedding — `ptts-pyo3`'s
  `get_state_for_embeddings` needs the latter before it can port fully.

[`refactor/share-loading-helpers`]: https://github.com/davencyw/xn-ptts/tree/refactor/share-loading-helpers
