### PR TITLE
fix: parse the voice safetensors header without the data section

### DIFF
--- a/ptts/Cargo.toml
+++ b/ptts/Cargo.toml
@@ -15,6 +15,7 @@ ebur128 = { workspace = true }
 rand = { workspace = true, features = ["std_rng"] }
 rand_distr = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 sentencepiece = { workspace = true, optional = true }
@@ -27,7 +28,6 @@ clap = { workspace = true }
 half = { workspace = true }
 hf-hub = { workspace = true }
 rubato = { workspace = true }
-serde_json = { workspace = true }
 symphonia = { workspace = true }
 tracing-chrome = { workspace = true }
 

--- a/ptts/src/loader.rs
+++ b/ptts/src/loader.rs
@@ -95,20 +95,46 @@ pub fn load_voice_emb<B: Backend>(
 /// Fails if the voice file records a `model_ext` other than `model_ext`. A file that records
 /// none is accepted: older voices predate the metadata.
 fn check_model_ext(path: &std::path::Path, model_ext: &str) -> Result<()> {
-    let file_content = std::fs::read(path)?;
-    let (_, metadata) =
-        safetensors::SafeTensors::read_metadata(&file_content).map_err(xn::Error::wrap)?;
-    if let Some(metadata) = metadata.metadata()
-        && let Some(voice_model_ext) = metadata.get("model_ext")
+    let header = read_safetensors_header(path)?;
+    // Not `SafeTensors::read_metadata`: it validates that the buffer holds the
+    // tensor data as well as the header, which is exactly what is not read here.
+    let header: serde_json::Value = serde_json::from_slice(&header).map_err(|e| {
+        xn::Error::msg(format!("cannot parse safetensors header of {}: {e}", path.display()))
+    })?;
+    if let Some(voice_model_ext) = header.get("__metadata__").and_then(|m| m.get("model_ext"))
+        && let Some(voice_model_ext) = voice_model_ext.as_str()
     {
         tracing::info!(?voice_model_ext, "voice embedding model_ext from metadata");
-        if voice_model_ext.as_str() != model_ext {
+        if voice_model_ext != model_ext {
             xn::bail!(
                 "voice embedding model_ext '{voice_model_ext}' does not match config model_ext '{model_ext}'"
             )
         }
     }
     Ok(())
+}
+
+/// Reads a safetensors file's JSON header: the 8-byte little-endian header
+/// length, then that many bytes.
+///
+/// `load_voice_emb` is called once per voice while a model loads, and the
+/// published checkpoint ships eight of them, so reading whole files here would
+/// double the bytes touched at startup for no reason.
+fn read_safetensors_header(path: &std::path::Path) -> Result<Vec<u8>> {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path)?;
+    let mut len_bytes = [0u8; 8];
+    file.read_exact(&mut len_bytes)?;
+    let header_len = u64::from_le_bytes(len_bytes);
+    // A file that is not safetensors can claim an absurd header length; refuse
+    // to allocate on its word.
+    if header_len > 100 * 1024 * 1024 {
+        xn::bail!("{} does not look like a safetensors file", path.display())
+    }
+    let mut buf = vec![0u8; header_len as usize];
+    file.read_exact(&mut buf)?;
+    Ok(buf)
 }
 
 #[cfg(test)]
@@ -159,6 +185,32 @@ mod tests {
             remap_key("flow_lm.flow.layers.0.weight").as_deref(),
             Some("flow_lm.flow_net.layers.0.weight")
         );
+    }
+
+    #[test]
+    fn model_ext_is_read_from_a_header_only_read() {
+        // One f32 of tensor data, so the header alone is not the whole file:
+        // `check_model_ext` must not need the data section to parse the header.
+        let write = |name: &str, header: &str| {
+            let path = std::env::temp_dir().join(name);
+            let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+            bytes.extend_from_slice(header.as_bytes());
+            bytes.extend_from_slice(&0f32.to_le_bytes());
+            std::fs::write(&path, &bytes).unwrap();
+            path
+        };
+        let tensor = r#""emb":{"dtype":"F32","shape":[1,1,1],"data_offsets":[0,4]}"#;
+
+        let matching = write(
+            "ptts-loader-voice-match.safetensors",
+            &format!(r#"{{"__metadata__":{{"model_ext":"abc@1"}},{tensor}}}"#),
+        );
+        check_model_ext(&matching, "abc@1").unwrap();
+        assert!(check_model_ext(&matching, "def@2").is_err());
+
+        // A voice from before the metadata existed is accepted as-is.
+        let bare = write("ptts-loader-voice-bare.safetensors", &format!(r#"{{{tensor}}}"#));
+        check_model_ext(&bare, "abc@1").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
### Why

Every time a model loads, we read all eight voice files from start to finish
just to check one string in their metadata. That is a lot of wasted disk reads
at startup.

We cannot simply read less. `SafeTensors::read_metadata` needs the whole file in
the buffer, so to read only the header we have to parse it ourselves.

This PR does not depend on the others. It changes one function, so it is the
easiest one to review and can go in first.

### What changes

`check_model_ext` reads the 8-byte little-endian header length, then that many
bytes, and parses the JSON itself. A header length is validated before it is
used to allocate, so a file that is not safetensors cannot ask for an absurd
buffer.

`serde_json` moves from dev-dependencies into the library for the parse.

### Test

`model_ext_is_read_from_a_header_only_read` writes a file whose header is
followed by real tensor bytes, so a regression to a whole-file read still passes
while a regression to "the header must be the whole file" does not. Voices from
before the metadata existed are still accepted.

### The stack

| | PR | What | Size |
|---|---|---|---|
| 1 | #31 | safetensors header-only read | +59/−7 |
| 2 | #32 | `ptts::plan` — frame budget, EOS policy | +196/−36 |
| 3 | #33 | `ReplayRng`, boxed `Rng`, `write_wav_file` | +104/−39 |
| 4 | #34 | `loader::ModelSource` + `hub` feature | +313/−2 |
| 5 | #35 | `SynthOf<Q>` — the pipeline | +957 |
| 6 | #36 | `Synth` — runtime format dispatch | +335/−28 |
| 7 | #37 | `pocket_tts` on `Synth`, `say` example | +203/−493 |

Each PR is one commit and is based on the one above it, so review top-down. The
tip carries the same behavior as `feat/synth-on-loader` (#27), which these
replace; #37 lists the deliberate differences.
