### PR TITLE
refactor: extract the frame budget and EOS policy into ptts::plan

### DIFF
--- a/ptts/examples/bench.rs
+++ b/ptts/examples/bench.rs
@@ -11,8 +11,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use model_helpers::max_frames_for;
 use ptts::flow_lm::NormalRng;
+use ptts::plan::{EosPolicy, frame_budget};
 use ptts::tok::Tok;
 use ptts::tts_model::{TTSConfig, TTSModel, TTSState};
 use xn::{BackendQ, Tensor};
@@ -97,6 +97,7 @@ fn one<Q: BackendQ>(
     base_state: &TTSState<Q>,
     chunks: &[(Vec<u32>, usize)],
     args: &Args,
+    frame_rate: f64,
 ) -> Result<Run> {
     let dev = model.device();
     let ldim = model.flow_lm.ldim;
@@ -116,9 +117,9 @@ fn one<Q: BackendQ>(
         // BOS marker: an all-NaN latent.
         let nan: Tensor<f32, Q::B> = Tensor::from_vec(vec![f32::NAN; ldim], (1, 1, ldim), dev)?;
         let mut prev_latent = nan.to::<Q::T>()?;
-        let mut eos_countdown: Option<usize> = None;
+        let mut eos = EosPolicy::new(*frames_after_eos);
 
-        for _ in 0..max_frames_for(tokens.len()) {
+        for _ in 0..frame_budget(tokens.len(), frame_rate) {
             let frame_start = Instant::now();
             let (next_latent, is_eos) = model.generate_step(&mut state, &prev_latent, &mut rng)?;
             let sampled = Instant::now();
@@ -134,14 +135,8 @@ fn one<Q: BackendQ>(
                 samples += pcm.len();
             }
 
-            if is_eos && eos_countdown.is_none() {
-                eos_countdown = Some(*frames_after_eos);
-            }
-            if let Some(countdown) = eos_countdown.as_mut() {
-                if *countdown == 0 {
-                    break;
-                }
-                *countdown -= 1;
+            if eos.should_stop(is_eos) {
+                break;
             }
             prev_latent = next_latent;
         }
@@ -250,7 +245,9 @@ impl Bench<'_> {
         let voice_len = voice_emb.dim(1usize)?;
         let seq_budget = chunks
             .iter()
-            .map(|(tokens, _)| voice_len + tokens.len() + max_frames_for(tokens.len()))
+            .map(|(tokens, _)| {
+                voice_len + tokens.len() + frame_budget(tokens.len(), cfg.mimi.frame_rate)
+            })
             .max()
             .unwrap_or(voice_len);
         let t_voice = Instant::now();
@@ -259,11 +256,11 @@ impl Bench<'_> {
         let voice_ms = ms(t_voice.elapsed());
 
         for _ in 0..args.warmup {
-            one(&model, &base_state, &chunks, args)?;
+            one(&model, &base_state, &chunks, args, cfg.mimi.frame_rate)?;
         }
         let mut runs = Vec::with_capacity(args.iters);
         for i in 0..args.iters {
-            let r = one(&model, &base_state, &chunks, args)?;
+            let r = one(&model, &base_state, &chunks, args, cfg.mimi.frame_rate)?;
             if args.per_iter {
                 println!(
                     "iter {i:>3}: total {:>8.2}ms  ttfa {:>7.2}ms  frames {:>4}",

--- a/ptts/examples/model_helpers.rs
+++ b/ptts/examples/model_helpers.rs
@@ -1,14 +1,11 @@
 //! Bits the examples share that are not worth a place in the library.
 //!
-//! Weight loading, key remapping and voice-embedding loading now live in `ptts::loader`, and
-//! the tokenizer in `ptts::tok`; this re-exports them so each example has one place to look.
+//! Weight loading, key remapping and voice-embedding loading now live in `ptts::loader`, the
+//! tokenizer in `ptts::tok` and the frame budget in `ptts::plan`; this re-exports the first two
+//! so each example has one place to look. `ptts::plan` is used directly, since it is not tied
+//! to a backend type.
 #![allow(dead_code, unused_imports)]
 
 pub use ptts::loader::{is_unused_by_tts_model, load_voice_emb, load_weights, remap_key};
 #[cfg(feature = "sp")]
 pub use ptts::tok::Tok;
-
-/// Frames an utterance of `num_tokens` tokens is allowed to generate before it is cut off.
-pub fn max_frames_for(num_tokens: usize) -> usize {
-    ((num_tokens as f64 / 3.0 + 2.0) * 12.5).ceil() as usize
-}

--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -5,8 +5,8 @@ mod model_helpers;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use model_helpers::max_frames_for;
 use ptts::flow_lm::NormalRng;
+use ptts::plan::{EosPolicy, frame_budget, seq_budget};
 use ptts::tok::Tok;
 use ptts::tts_model::{
     MimiEnc, TTSConfig, TTSModel, prepare_text_prompt, split_into_best_sentences,
@@ -390,9 +390,8 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
         let tokens = model.flow_lm.conditioner.tokenize(&text)?;
         let num_tokens = tokens.len();
         tracing::info!(?text, ?num_tokens, "processing text");
-        let max_frames = max_frames_for(num_tokens);
-        let seq_budget = num_tokens + 512 + max_frames;
-        max_seq_budget = max_seq_budget.max(seq_budget);
+        let max_frames = frame_budget(num_tokens, cfg.mimi.frame_rate);
+        max_seq_budget = max_seq_budget.max(seq_budget(num_tokens, max_frames));
         all_tokens.push((tokens, max_frames, frames_after_eos));
     }
     // Init states
@@ -504,7 +503,7 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
         let mut prev_latent: Tensor<Q::T, Q::B> =
             Tensor::from_vec(nan_data, (1, 1, ldim), &dev)?.to::<Q::T>()?;
 
-        let mut eos_countdown: Option<usize> = None;
+        let mut eos = EosPolicy::new(frames_after_eos);
 
         let (latent_tx, latent_rx) = std::sync::mpsc::channel::<Tensor<Q::T, _>>();
         let is_done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -560,16 +559,9 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
             backbone_step_timings_ms.push(step_start.elapsed().as_secs_f64() * 1000.0);
             latent_tx.send(next_latent.clone())?;
 
-            if is_eos && eos_countdown.is_none() {
-                eos_countdown = Some(frames_after_eos);
-            }
-
-            if let Some(ref mut countdown) = eos_countdown {
-                if *countdown == 0 {
-                    tracing::info!(?step, "reached eos");
-                    break;
-                }
-                *countdown -= 1;
+            if eos.should_stop(is_eos) {
+                tracing::info!(?step, "reached eos");
+                break;
             }
 
             prev_latent = next_latent;

--- a/ptts/src/lib.rs
+++ b/ptts/src/lib.rs
@@ -6,6 +6,7 @@ pub mod layer_scale;
 pub mod loader;
 pub mod mimi;
 pub mod mlp;
+pub mod plan;
 pub mod preprocess;
 pub mod resample;
 pub mod rope;

--- a/ptts/src/plan.rs
+++ b/ptts/src/plan.rs
@@ -1,0 +1,173 @@
+//! Generation policy: how many frames to run, how much KV budget to reserve, and
+//! when to stop.
+//!
+//! These rules were inlined — as literals — in every frontend: the `pocket_tts`
+//! and `bench` examples, `ptts-pyo3` (twice), `ptts-wasm` and `ptts-ws-server`
+//! each carried their own copy of `((n / 3.0 + 2.0) * 12.5).ceil()` and their own
+//! EOS countdown loop. They are pure functions of the token count and the config,
+//! so they belong here, where they can be unit tested once.
+//!
+//! The two examples are converted; `ptts-pyo3`, `ptts-wasm` and `ptts-ws-server`
+//! still carry their copies and are left for a follow-up, since each also has its
+//! own generation loop to untangle.
+
+/// Extra KV-cache entries reserved on top of the text tokens and the generated
+/// frames, covering the voice-prompt frames (~125 at 12.5Hz for a 10s prompt)
+/// plus slack.
+pub const PROMPT_SEQ_HEADROOM: usize = 512;
+
+/// Frames of audio to generate for a text prompt of `num_tokens` tokens.
+///
+/// Roughly three tokens per second of speech, plus two seconds of slack,
+/// converted to frames at the codec frame rate. This is an upper bound: normal
+/// generation stops earlier, when the model signals EOS (see [`EosPolicy`]).
+///
+/// `frame_rate` comes from `TTSConfig::mimi.frame_rate`. The frontends all
+/// hardcoded `12.5`, which silently assumed the shipped config.
+pub fn frame_budget(num_tokens: usize, frame_rate: f64) -> usize {
+    ((num_tokens as f64 / 3.0 + 2.0) * frame_rate).ceil() as usize
+}
+
+/// KV-cache length to allocate for a single text chunk: its text tokens, the
+/// frames it may generate, and [`PROMPT_SEQ_HEADROOM`] for the voice prompt.
+///
+/// A state is allocated once and reused across chunks, so callers with several
+/// chunks should allocate the max over all of them.
+pub fn seq_budget(num_tokens: usize, frame_budget: usize) -> usize {
+    num_tokens + PROMPT_SEQ_HEADROOM + frame_budget
+}
+
+/// Tracks the tail of a generation: once the model reports EOS, a few more
+/// frames are still emitted so the codec can close out the utterance cleanly.
+///
+/// `frames_after_eos` comes from [`crate::tts_model::prepare_text_prompt`] — 3
+/// for very short prompts, 1 otherwise.
+#[derive(Clone, Copy, Debug)]
+pub struct EosPolicy {
+    frames_after_eos: usize,
+    countdown: Option<usize>,
+}
+
+impl EosPolicy {
+    pub fn new(frames_after_eos: usize) -> Self {
+        Self { frames_after_eos, countdown: None }
+    }
+
+    /// Records the EOS flag of the frame that was just generated and returns
+    /// whether generation should stop now.
+    ///
+    /// Call this once per frame, *after* the frame has been handed to the
+    /// decoder — the EOS frame itself is part of the output.
+    pub fn should_stop(&mut self, is_eos: bool) -> bool {
+        if is_eos && self.countdown.is_none() {
+            self.countdown = Some(self.frames_after_eos);
+        }
+        match self.countdown.as_mut() {
+            None => false,
+            Some(0) => true,
+            Some(countdown) => {
+                *countdown -= 1;
+                false
+            }
+        }
+    }
+
+    /// True once the model has signalled EOS, whether or not the tail has run out.
+    pub fn saw_eos(&self) -> bool {
+        self.countdown.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_budget_matches_the_frontends() {
+        // The literal every frontend carried: ((n / 3 + 2) * 12.5).ceil().
+        for n in [0usize, 1, 7, 12, 50, 137] {
+            let expected = ((n as f64 / 3.0 + 2.0) * 12.5).ceil() as usize;
+            assert_eq!(frame_budget(n, 12.5), expected, "n = {n}");
+        }
+        assert_eq!(frame_budget(0, 12.5), 25);
+        assert_eq!(frame_budget(50, 12.5), 234);
+    }
+
+    #[test]
+    fn frame_budget_follows_the_frame_rate() {
+        assert_eq!(frame_budget(30, 12.5), frame_budget(30, 25.0) / 2);
+    }
+
+    #[test]
+    fn seq_budget_covers_tokens_frames_and_headroom() {
+        assert_eq!(seq_budget(40, 234), 40 + 512 + 234);
+    }
+
+    /// Reference implementation, transcribed from `pocket_tts.rs` before the
+    /// refactor. `EosPolicy` must agree with it frame for frame.
+    fn reference(eos_at: Option<usize>, frames_after_eos: usize, max_frames: usize) -> usize {
+        let mut eos_countdown: Option<usize> = None;
+        let mut emitted = 0;
+        for step in 0..max_frames {
+            emitted += 1;
+            let is_eos = eos_at == Some(step);
+            if is_eos && eos_countdown.is_none() {
+                eos_countdown = Some(frames_after_eos);
+            }
+            if let Some(ref mut countdown) = eos_countdown {
+                if *countdown == 0 {
+                    break;
+                }
+                *countdown -= 1;
+            }
+        }
+        emitted
+    }
+
+    fn under_test(eos_at: Option<usize>, frames_after_eos: usize, max_frames: usize) -> usize {
+        let mut policy = EosPolicy::new(frames_after_eos);
+        let mut emitted = 0;
+        for step in 0..max_frames {
+            emitted += 1;
+            if policy.should_stop(eos_at == Some(step)) {
+                break;
+            }
+        }
+        emitted
+    }
+
+    #[test]
+    fn eos_policy_matches_the_reference_loop() {
+        for frames_after_eos in [0usize, 1, 3] {
+            for eos_at in [None, Some(0), Some(1), Some(5), Some(19)] {
+                for max_frames in [1usize, 6, 20] {
+                    assert_eq!(
+                        under_test(eos_at, frames_after_eos, max_frames),
+                        reference(eos_at, frames_after_eos, max_frames),
+                        "frames_after_eos = {frames_after_eos}, eos_at = {eos_at:?}, max = {max_frames}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn eos_policy_emits_the_eos_frame_plus_the_tail() {
+        // EOS on frame 5 with a 1-frame tail: frames 0..=6 are emitted.
+        assert_eq!(under_test(Some(5), 1, 100), 7);
+        // A 3-frame tail emits three more.
+        assert_eq!(under_test(Some(5), 3, 100), 9);
+        // No EOS: capped by max_frames.
+        assert_eq!(under_test(None, 1, 100), 100);
+    }
+
+    #[test]
+    fn eos_policy_reports_eos() {
+        let mut policy = EosPolicy::new(1);
+        assert!(!policy.saw_eos());
+        policy.should_stop(false);
+        assert!(!policy.saw_eos());
+        policy.should_stop(true);
+        assert!(policy.saw_eos());
+    }
+}


### PR DESCRIPTION
### Why

Three rules control how long a generation runs. All three are copy-pasted
numbers spread across five frontends, and none of them are tested.

One of them hardcodes the frame rate as `12.5`. If someone changes
`mimi.frame_rate` in the config, all five copies become wrong and nothing tells
us.

#35 also needs one place to call. Without this it would add a sixth copy.

### What changes

| Rule | How it appeared | Now |
|---|---|---|
| Frame budget | `((n / 3.0 + 2.0) * 12.5).ceil()`, 5 places | `plan::frame_budget(n, frame_rate)` |
| KV headroom | a bare `+ 512` | `plan::seq_budget` / `PROMPT_SEQ_HEADROOM` |
| EOS tail | an 8-line `Option<usize>` countdown, 5 places | `plan::EosPolicy` |

`frame_budget` takes the frame rate from `TTSConfig::mimi.frame_rate` instead of
assuming `12.5`. The shipped config *is* 12.5, so no current output changes.

### Equivalence is tested, not asserted

`eos_policy_matches_the_reference_loop` runs `EosPolicy` against a transcription
of the loop it replaces, over every combination of tail length (0/1/3), EOS frame
(none/0/1/5/19) and cap (1/6/20), comparing emitted frame counts.

### Scope

The `pocket_tts` and `bench` examples are converted. `ptts-pyo3`, `ptts-wasm`
and `ptts-ws-server` still carry their copies — each also has its own generation
loop to untangle, so they are left for a follow-up. The module doc says so.

### The stack

| | PR | What | Size |
|---|---|---|---|
| 1 | #31 | safetensors header-only read | +59/−7 |
| 2 | #32 | `ptts::plan` — frame budget, EOS policy | +196/−36 |
| 3 | #33 | `ReplayRng`, boxed `Rng`, `write_wav_file` | +104/−39 |
| 4 | #34 | `loader::ModelSource` + `hub` feature | +313/−2 |
| 5 | #35 | `SynthOf<Q>` — the pipeline | +957 |
| 6 | #36 | `Synth` — runtime format dispatch | +335/−28 |
| 7 | #37 | `pocket_tts` on `Synth`, `say` example | +203/−493 |

Each PR is one commit and is based on the one above it, so review top-down. The
tip carries the same behavior as `feat/synth-on-loader` (#27), which these
replace; #37 lists the deliberate differences.
