### PR TITLE
feat: move the replay noise source into the library

### DIFF
--- a/ptts/examples/pocket_tts.rs
+++ b/ptts/examples/pocket_tts.rs
@@ -5,7 +5,7 @@ mod model_helpers;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use ptts::flow_lm::NormalRng;
+use ptts::flow_lm::{NormalRng, ReplayRng};
 use ptts::plan::{EosPolicy, frame_budget, seq_budget};
 use ptts::tok::Tok;
 use ptts::tts_model::{
@@ -260,41 +260,6 @@ fn peak_rss_mb() -> Option<f64> {
     None
 }
 
-/// Either the library's seeded sampler, or a canned list of values replayed from a file, which
-/// is how a run is made to match a reference trace exactly.
-enum Rng {
-    Normal(Box<NormalRng>),
-    FromFile { values: Vec<f32>, index: usize },
-}
-
-impl Rng {
-    pub fn std_rng(temperature: f32, seed: u64) -> Result<Self> {
-        Ok(Self::Normal(Box::new(NormalRng::new(temperature, seed)?)))
-    }
-
-    pub fn from_file(path: &str) -> Result<Self> {
-        let file = std::fs::read_to_string(path)?;
-        let values = serde_json::from_str::<Vec<f32>>(&file)?;
-        Ok(Self::FromFile { values, index: 0 })
-    }
-}
-
-impl ptts::flow_lm::Rng for Rng {
-    fn sample(&mut self) -> f32 {
-        match self {
-            Self::Normal(rng) => rng.sample(),
-            Self::FromFile { values, index } => {
-                if *index >= values.len() {
-                    *index = 0;
-                }
-                let val = values[*index];
-                *index += 1;
-                val
-            }
-        }
-    }
-}
-
 fn spawn<F, R>(f: F) -> std::thread::JoinHandle<R>
 where
     F: FnOnce() -> Result<R>,
@@ -363,9 +328,12 @@ fn run_for_device<Q: xn::BackendQ + 'static>(args: Args, dev: Q::B) -> Result<()
     };
     let chunks = split_into_best_sentences(&tokenizer, &text, None)?;
 
-    let mut rng = match args.rng_values {
-        Some(path) => Rng::from_file(&path)?,
-        None => Rng::std_rng(args.temperature, args.seed)?,
+    let mut rng: Box<dyn ptts::flow_lm::Rng + Send> = match args.rng_values {
+        Some(path) => {
+            let values: Vec<f32> = serde_json::from_str(&std::fs::read_to_string(path)?)?;
+            Box::new(ReplayRng::new(values)?)
+        }
+        None => Box::new(NormalRng::new(args.temperature, args.seed)?),
     };
 
     tracing::info!(

--- a/ptts/src/flow_lm.rs
+++ b/ptts/src/flow_lm.rs
@@ -33,6 +33,41 @@ impl Rng for NormalRng {
     }
 }
 
+/// Lets a boxed noise source be passed where an `impl Rng` is expected, so a
+/// caller can choose one at runtime.
+impl Rng for Box<dyn Rng + Send> {
+    fn sample(&mut self) -> f32 {
+        (**self).sample()
+    }
+}
+
+/// Replays a fixed sequence of values, cycling when exhausted.
+///
+/// The sampler's only source of randomness is [`Rng`], so feeding it a recorded
+/// sequence makes a generation reproducible across implementations — which is
+/// how this crate is compared against the reference one step for step.
+pub struct ReplayRng {
+    values: Vec<f32>,
+    index: usize,
+}
+
+impl ReplayRng {
+    pub fn new(values: Vec<f32>) -> Result<Self> {
+        if values.is_empty() {
+            xn::bail!("ReplayRng needs at least one value")
+        }
+        Ok(Self { values, index: 0 })
+    }
+}
+
+impl Rng for ReplayRng {
+    fn sample(&mut self) -> f32 {
+        let value = self.values[self.index % self.values.len()];
+        self.index += 1;
+        value
+    }
+}
+
 /// Lagrangian Self Distillation decode.
 /// Rebuilds the data sample from starting point x_0.
 fn lsd_decode<T: WithDTypeF, B: Backend>(
@@ -279,5 +314,50 @@ impl<Q: BackendQ> FlowLM<Q> {
             }
         }
         Tensor::from_vec(out_data, sequence.shape().clone(), sequence.device())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normal_rng_is_reproducible_from_its_seed() {
+        let mut a = NormalRng::new(0.7, 42).unwrap();
+        let mut b = NormalRng::new(0.7, 42).unwrap();
+        for _ in 0..16 {
+            assert_eq!(a.sample(), b.sample());
+        }
+    }
+
+    #[test]
+    fn normal_rng_differs_between_seeds() {
+        let mut a = NormalRng::new(0.7, 1).unwrap();
+        let mut b = NormalRng::new(0.7, 2).unwrap();
+        let xs: Vec<f32> = (0..8).map(|_| a.sample()).collect();
+        let ys: Vec<f32> = (0..8).map(|_| b.sample()).collect();
+        assert_ne!(xs, ys);
+    }
+
+    #[test]
+    fn zero_temperature_removes_the_noise() {
+        // std = sqrt(0) = 0, so the sampler becomes deterministic rather than erroring.
+        let mut rng = NormalRng::new(0.0, 7).unwrap();
+        for _ in 0..8 {
+            assert_eq!(rng.sample(), 0.0);
+        }
+    }
+
+    #[test]
+    fn replay_rng_cycles_and_rejects_empty() {
+        let mut rng = ReplayRng::new(vec![1.0, 2.0]).unwrap();
+        assert_eq!([rng.sample(), rng.sample(), rng.sample()], [1.0, 2.0, 1.0]);
+        assert!(ReplayRng::new(vec![]).is_err());
+    }
+
+    #[test]
+    fn a_boxed_rng_forwards_to_its_inner_source() {
+        let mut boxed: Box<dyn Rng + Send> = Box::new(ReplayRng::new(vec![3.0, 4.0]).unwrap());
+        assert_eq!([boxed.sample(), boxed.sample()], [3.0, 4.0]);
     }
 }

--- a/ptts/src/wav.rs
+++ b/ptts/src/wav.rs
@@ -54,3 +54,20 @@ pub fn write_pcm_as_wav<W: Write, S: Sample>(
     }
     Ok(())
 }
+
+/// Write mono PCM to a WAV file at `path`.
+///
+/// A convenience over [`write_pcm_as_wav`] for the common case of saving a
+/// finished generation: open the file, wrap it in a `BufWriter`, write, flush.
+pub fn write_wav_file<P: AsRef<std::path::Path>>(
+    path: P,
+    pcm: &[f32],
+    sample_rate: u32,
+) -> xn::Result<()> {
+    let file = std::fs::File::create(path.as_ref())
+        .map_err(|e| xn::Error::msg(format!("cannot create {}: {e}", path.as_ref().display())))?;
+    let mut writer = std::io::BufWriter::new(file);
+    write_pcm_as_wav(&mut writer, pcm, sample_rate, 1).map_err(xn::Error::wrap)?;
+    writer.flush().map_err(xn::Error::wrap)?;
+    Ok(())
+}


### PR DESCRIPTION
### Why

#35 needs to accept either a random sampler or a recorded list of numbers,
through the same function signature. For that, `Rng` has to work on
`Box<dyn Rng + Send>`, and right now it does not.

We also use recorded noise to check our output matches the reference
implementation exactly. That code sits inside one example today, so tests and
the other frontends cannot use it.

### What changes

`ptts::flow_lm` gains `ReplayRng`, which cycles a fixed sequence, and
`impl Rng for Box<dyn Rng + Send>`. The `pocket_tts` example's private enum with
its `Normal` and `FromFile` arms goes away.

The library version rejects an empty value list, which the example indexed into
and panicked on.

Also adds `wav::write_wav_file`, so saving a finished generation is one call
instead of file / `BufWriter` / write / flush at each call site.

### The stack

| | PR | What | Size |
|---|---|---|---|
| 1 | #31 | safetensors header-only read | +59/−7 |
| 2 | #32 | `ptts::plan` — frame budget, EOS policy | +196/−36 |
| 3 | #33 | `ReplayRng`, boxed `Rng`, `write_wav_file` | +104/−39 |
| 4 | #34 | `loader::ModelSource` + `hub` feature | +313/−2 |
| 5 | #35 | `SynthOf<Q>` — the pipeline | +957 |
| 6 | #36 | `Synth` — runtime format dispatch | +335/−28 |
| 7 | #37 | `pocket_tts` on `Synth`, `say` example | +203/−493 |

Each PR is one commit and is based on the one above it, so review top-down. The
tip carries the same behavior as `feat/synth-on-loader` (#27), which these
replace; #37 lists the deliberate differences.
