### PR TITLE
feat: add loader::ModelSource, one place that decides which files to load

### DIFF
--- a/ptts/Cargo.toml
+++ b/ptts/Cargo.toml
@@ -15,12 +15,16 @@ ebur128 = { workspace = true }
 rand = { workspace = true, features = ["std_rng"] }
 rand_distr = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+safetensors = { workspace = true }
+serde_json = { workspace = true }
+# Optional: `hf-hub` for `ModelSource::Hub` (pulls in ureq, so it must stay out
+# of the wasm build), and one of `sentencepiece` / `tokenizers` for reading a
+# tokenizer out of a checkpoint.
+hf-hub = { workspace = true, optional = true }
 sentencepiece = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
-safetensors = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -44,6 +48,8 @@ accelerate = ["xn/accelerate"]
 sp = ["dep:sentencepiece"]
 # Hugging Face `tokenizers` support in `ptts::tok`.
 hf = ["dep:tokenizers"]
+# Download checkpoints from the Hugging Face Hub (`ModelSource::Hub`).
+hub = ["dep:hf-hub"]
 
 [[example]]
 name = "pocket_tts"

--- a/ptts/src/loader.rs
+++ b/ptts/src/loader.rs
@@ -4,6 +4,7 @@
 //! rename the same checkpoint keys, skip the same unused tensors and unpack voice files the same
 //! way. Keeping that here means a checkpoint layout change is one edit rather than four.
 
+use crate::tts_model::TTSConfig;
 use xn::nn::{Path, VB};
 use xn::{Backend, BackendQ, Result, Tensor};
 
@@ -214,6 +215,76 @@ mod tests {
     }
 
     #[test]
+    fn a_missing_directory_names_itself() {
+        let err = ModelSource::Dir("/definitely/not/a/model/dir".into())
+            .resolve(0.7)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("/definitely/not/a/model/dir"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_directory_lists_the_weight_files_it_looked_for() {
+        let dir = std::env::temp_dir().join("ptts-loader-empty-dir");
+        std::fs::create_dir_all(&dir).unwrap();
+        let err = ModelSource::Dir(dir.clone()).resolve(0.7).unwrap_err().to_string();
+        assert!(err.contains("model.safetensors"), "should list the candidates: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_directory_with_no_config_falls_back_to_the_shipped_one() {
+        let dir = std::env::temp_dir().join("ptts-loader-no-config");
+        std::fs::create_dir_all(dir.join("voices")).unwrap();
+        std::fs::write(dir.join("model.safetensors"), b"").unwrap();
+        std::fs::write(dir.join("voices/freya.safetensors"), b"").unwrap();
+        std::fs::write(dir.join("tokenizer.model"), b"").unwrap();
+
+        let artifacts = ModelSource::Dir(dir.clone()).resolve(0.5).unwrap();
+        assert_eq!(artifacts.weights, dir.join("model.safetensors"));
+        assert_eq!(artifacts.tokenizer, Some(dir.join("tokenizer.model")));
+        assert_eq!(
+            artifacts.voices,
+            vec![("freya".to_string(), dir.join("voices/freya.safetensors"))]
+        );
+        // The temperature the caller asked for overrides whatever the config carries.
+        assert_eq!(artifacts.config.temp, 0.5);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn missing_explicit_weights_name_the_path() {
+        let source = ModelSource::Files {
+            config: None,
+            weights: "/nope/weights.safetensors".into(),
+            tokenizer: None,
+        };
+        let err = source.resolve(0.7).unwrap_err().to_string();
+        assert!(err.contains("/nope/weights.safetensors"), "{err}");
+    }
+
+    #[test]
+    fn an_unparseable_config_names_the_file() {
+        let path = std::env::temp_dir().join("ptts-loader-bad-config.json");
+        std::fs::write(&path, "{ not json").unwrap();
+        let source = ModelSource::Files {
+            config: Some(path.clone()),
+            weights: "/nope".into(),
+            tokenizer: None,
+        };
+        let err = source.resolve(0.7).unwrap_err().to_string();
+        assert!(err.contains("ptts-loader-bad-config.json"), "{err}");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[cfg(not(feature = "hub"))]
+    #[test]
+    fn the_hub_path_says_which_feature_is_missing() {
+        let err = ModelSource::hub().resolve(0.7).unwrap_err().to_string();
+        assert!(err.contains("hub"), "{err}");
+    }
+
+    #[test]
     fn unused_tensors_are_recognized() {
         for unused in [
             "flow_lm.condition_provider.conditioners.speaker_wavs.learnt_padding",
@@ -228,5 +299,239 @@ mod tests {
         }
         assert!(!is_unused_by_tts_model("flow_lm.transformer.layers.0.linear1.weight"));
         assert!(!is_unused_by_tts_model("mimi.decoder.layers.0.weight"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Where a checkpoint comes from
+// ---------------------------------------------------------------------------
+
+/// Voice embeddings shipped with the published checkpoint.
+pub const VOICES: &[&str] =
+    &["alba", "marius", "javert", "jean", "fantine", "cosette", "eponine", "azelma"];
+
+/// Default Hugging Face repo for the published weights.
+pub const DEFAULT_REPO_ID: &str = "kyutai/pocket-tts";
+
+/// Weight file names tried, in order, when the source does not name one.
+pub const WEIGHT_CANDIDATES: &[&str] =
+    &["model.safetensors", "model.q8.gguf", "tts_b6369a24.safetensors"];
+
+/// Tokenizer file names tried, in order. `tokenizer.json` is the Hugging Face
+/// `tokenizers` format, `tokenizer.model` is SentencePiece; [`crate::tok::Tok`]
+/// picks the reader by extension.
+pub const TOKENIZER_CANDIDATES: &[&str] = &["tokenizer.json", "tokenizer.model"];
+
+/// Where to load a checkpoint from.
+///
+/// [`load_weights`] and [`load_voice_emb`] read files that someone has already
+/// located; this decides *which* files, across the three layouts in use — the
+/// published Hub repo, a local model directory, and explicit paths.
+#[derive(Clone, Debug)]
+pub enum ModelSource {
+    /// A Hugging Face model repo. Requires the `hub` feature.
+    Hub { repo_id: String, weights: Option<String> },
+    /// A local directory holding `config.json`, a weights file, a tokenizer and
+    /// an optional `voices/` or `embeddings/` subdirectory.
+    Dir(std::path::PathBuf),
+    /// Explicit file paths. `config` defaults to [`TTSConfig::v202601`] when absent.
+    Files {
+        config: Option<std::path::PathBuf>,
+        weights: std::path::PathBuf,
+        tokenizer: Option<std::path::PathBuf>,
+    },
+}
+
+impl ModelSource {
+    /// The published checkpoint on the Hugging Face Hub.
+    pub fn hub() -> Self {
+        Self::Hub { repo_id: DEFAULT_REPO_ID.to_string(), weights: None }
+    }
+
+    /// A specific Hugging Face repo, with the default weight-file search order.
+    pub fn hub_repo(repo_id: impl Into<String>) -> Self {
+        Self::Hub { repo_id: repo_id.into(), weights: None }
+    }
+
+    /// Locate every file this source provides, downloading if needed, and parse
+    /// the config.
+    pub fn resolve(&self, temperature: f32) -> Result<Artifacts> {
+        match self {
+            Self::Hub { repo_id, weights } => resolve_hub(repo_id, weights.as_deref(), temperature),
+            Self::Dir(dir) => resolve_dir(dir, temperature),
+            Self::Files { config, weights, tokenizer } => {
+                let config = match config {
+                    Some(path) => read_config(path, temperature)?,
+                    None => TTSConfig::v202601(temperature),
+                };
+                if !weights.is_file() {
+                    xn::bail!("weights file not found: {}", weights.display())
+                }
+                Ok(Artifacts {
+                    config,
+                    weights: weights.clone(),
+                    tokenizer: tokenizer.clone(),
+                    voices: vec![],
+                })
+            }
+        }
+    }
+}
+
+/// A checkpoint's files, located and its config parsed, ready to load.
+#[derive(Clone, Debug)]
+pub struct Artifacts {
+    pub config: TTSConfig,
+    pub weights: std::path::PathBuf,
+    /// `None` when the source carries no tokenizer file; the caller must then
+    /// supply a tokenizer itself.
+    pub tokenizer: Option<std::path::PathBuf>,
+    /// Voice name to embedding file, sorted by name.
+    pub voices: Vec<(String, std::path::PathBuf)>,
+}
+
+fn read_config(path: &std::path::Path, temperature: f32) -> Result<TTSConfig> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| xn::Error::msg(format!("cannot read config {}: {e}", path.display())))?;
+    let mut cfg: TTSConfig = serde_json::from_str(&text)
+        .map_err(|e| xn::Error::msg(format!("cannot parse config {}: {e}", path.display())))?;
+    cfg.temp = temperature;
+    Ok(cfg)
+}
+
+fn resolve_dir(dir: &std::path::Path, temperature: f32) -> Result<Artifacts> {
+    if !dir.is_dir() {
+        xn::bail!("not a directory: {}", dir.display())
+    }
+    let config_path = dir.join("config.json");
+    let config = if config_path.is_file() {
+        read_config(&config_path, temperature)?
+    } else {
+        TTSConfig::v202601(temperature)
+    };
+
+    let weights = WEIGHT_CANDIDATES
+        .iter()
+        .map(|name| dir.join(name))
+        .find(|path| path.is_file())
+        .ok_or_else(|| {
+        xn::Error::msg(format!(
+            "no weights file in {}; expected one of {}",
+            dir.display(),
+            WEIGHT_CANDIDATES.join(", ")
+        ))
+    })?;
+
+    let tokenizer =
+        TOKENIZER_CANDIDATES.iter().map(|name| dir.join(name)).find(|path| path.is_file());
+
+    let mut voices = vec![];
+    for sub in ["voices", "embeddings"] {
+        collect_voice_dir(&dir.join(sub), &mut voices);
+    }
+    let default_voice = dir.join("default-voice.safetensors");
+    if default_voice.is_file() {
+        voices.push(("default".to_string(), default_voice));
+    }
+    voices.sort();
+    voices.dedup_by(|a, b| a.0 == b.0);
+
+    Ok(Artifacts { config, weights, tokenizer, voices })
+}
+
+/// Adds every `*.safetensors` file in `dir` to `voices`, keyed by file stem. A
+/// missing or unreadable directory is not an error: voices are optional.
+fn collect_voice_dir(dir: &std::path::Path, voices: &mut Vec<(String, std::path::PathBuf)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("safetensors") {
+            continue;
+        }
+        if let Some(name) = path.file_stem().and_then(|s| s.to_str()) {
+            voices.push((name.to_string(), path));
+        }
+    }
+}
+
+#[cfg(not(feature = "hub"))]
+fn resolve_hub(_: &str, _: Option<&str>, _: f32) -> Result<Artifacts> {
+    xn::bail!(
+        "loading from the Hugging Face Hub requires the `hub` feature of the `ptts` crate; \
+         use ModelSource::Dir or ModelSource::Files to load local files instead"
+    )
+}
+
+#[cfg(feature = "hub")]
+fn resolve_hub(repo_id: &str, weights: Option<&str>, temperature: f32) -> Result<Artifacts> {
+    let repo = HubRepo::open(repo_id)?;
+
+    let config = match repo.get_optional("config.json") {
+        Some(path) => read_config(&path, temperature)?,
+        None => TTSConfig::v202601(temperature),
+    };
+
+    let weights = match weights {
+        Some(name) => repo.get(name)?,
+        None => match WEIGHT_CANDIDATES.iter().find_map(|name| repo.get_optional(name)) {
+            Some(path) => path,
+            None => xn::bail!(
+                "no weights file in `{repo_id}`; expected one of {}",
+                WEIGHT_CANDIDATES.join(", ")
+            ),
+        },
+    };
+
+    let tokenizer = TOKENIZER_CANDIDATES.iter().find_map(|name| repo.get_optional(name));
+
+    let mut voices = vec![];
+    for voice in VOICES {
+        if let Some(path) = repo.get_optional(&format!("embeddings/{voice}.safetensors")) {
+            voices.push((voice.to_string(), path));
+        }
+    }
+    if let Some(path) = repo.get_optional("default-voice.safetensors") {
+        voices.push(("default".to_string(), path));
+    }
+    voices.sort();
+
+    Ok(Artifacts { config, weights, tokenizer, voices })
+}
+
+/// A Hugging Face model repo, wrapped so a download failure names the repo, the
+/// file and the URL — `hf_hub`'s own errors mention none of the three, which
+/// makes a gated repo or a renamed file hard to diagnose.
+#[cfg(feature = "hub")]
+struct HubRepo {
+    repo: hf_hub::api::sync::ApiRepo,
+    repo_id: String,
+}
+
+#[cfg(feature = "hub")]
+impl HubRepo {
+    fn open(repo_id: &str) -> Result<Self> {
+        use hf_hub::{Repo, RepoType, api::sync::Api};
+        let api = Api::new()
+            .map_err(|e| xn::Error::msg(format!("cannot reach the Hugging Face Hub: {e}")))?;
+        let repo = api.repo(Repo::new(repo_id.to_string(), RepoType::Model));
+        Ok(Self { repo, repo_id: repo_id.to_string() })
+    }
+
+    fn get(&self, filename: &str) -> Result<std::path::PathBuf> {
+        self.repo.get(filename).map_err(|e| {
+            let url = self.repo.url(filename);
+            xn::Error::msg(format!(
+                "failed to fetch `{filename}` from `{}` ({url}): {e}\n\
+                 If the repo is gated, accept its terms on huggingface.co and run \
+                 `huggingface-cli login` (or set HF_TOKEN).",
+                self.repo_id
+            ))
+        })
+    }
+
+    /// Like [`Self::get`] but maps any failure to `None`, for files that may
+    /// legitimately be absent from a given repo layout.
+    fn get_optional(&self, filename: &str) -> Option<std::path::PathBuf> {
+        self.repo.get(filename).ok()
     }
 }


### PR DESCRIPTION
### Why

To load a checkpoint you have to know its filenames, and every frontend
hardcodes its own set. The examples fetch three fixed names from the Hub,
`ptts-ws-server` and `ptts-pyo3` take paths, the wasm build gets raw bytes. Some
layouts keep voices in `voices/`, others in `embeddings/`. If a file is renamed
upstream, that is four places to fix.

#35 needs one thing that knows where files come from. It also has to be
optional, because `hf-hub` brings in `ureq` and that cannot go in the wasm
build.

### What changes

`load_weights` and `load_voice_emb` keep reading files someone else located;
`ModelSource` is what locates them, and `resolve` returns an `Artifacts` with
the config parsed and the weights, tokenizer and voices found:

```rust
pub enum ModelSource {
    Hub { repo_id: String, weights: Option<String> },
    Dir(PathBuf),
    Files { config: Option<PathBuf>, weights: PathBuf, tokenizer: Option<PathBuf> },
}
```

The scattered filename knowledge becomes three lists: `VOICES`,
`WEIGHT_CANDIDATES`, `TOKENIZER_CANDIDATES`. `Dir` accepts either `voices/` or
`embeddings/`, since both layouts are in circulation.

### The `hub` feature

Without it, `ModelSource::Hub` fails with the feature name and the local
alternatives, rather than a link error.

`HubRepo` wraps each fetch so a failure names the repo, the file and the URL, and
points at `HF_TOKEN` for a gated repo — `hf_hub`'s own errors mention none of
those three, which makes a renamed or gated file hard to diagnose.

### Note

Nothing calls this yet; #35 is the first consumer. Six tests cover the
resolution paths and their error messages.

### The stack

| | PR | What | Size |
|---|---|---|---|
| 1 | #31 | safetensors header-only read | +59/−7 |
| 2 | #32 | `ptts::plan` — frame budget, EOS policy | +196/−36 |
| 3 | #33 | `ReplayRng`, boxed `Rng`, `write_wav_file` | +104/−39 |
| 4 | #34 | `loader::ModelSource` + `hub` feature | +313/−2 |
| 5 | #35 | `SynthOf<Q>` — the pipeline | +957 |
| 6 | #36 | `Synth` — runtime format dispatch | +335/−28 |
| 7 | #37 | `pocket_tts` on `Synth`, `say` example | +203/−493 |

Each PR is one commit and is based on the one above it, so review top-down. The
tip carries the same behavior as `feat/synth-on-loader` (#27), which these
replace; #37 lists the deliberate differences.
